### PR TITLE
Fixes typos, grammar and markdown syntax

### DIFF
--- a/book/If.md
+++ b/book/If.md
@@ -4,7 +4,7 @@ Rusts `if` ist nicht besonders kompliziert, aber es ähnelt viel mehr dem
 `if` einer dynamisch typisierten Sprache, als dem einer
 eher traditionellen Sprachen.
 
-Lass uns also darüber sprechen, um sicherzustellen, dass du die feinheiten
+Lass uns also darüber sprechen, um sicherzustellen, dass du die Feinheiten
 verstehst.
 
 `if` ist eine spezielle Form eines allgemeineren Konzeptes, dem Zweig [branch].

--- a/book/Kommentare.md
+++ b/book/Kommentare.md
@@ -43,9 +43,9 @@ fn add_one(x: i32) -> i32 {
 </code></pre>
 
 Es gibt noch eine weitere Kommentarform, nämlich `//!`,
-um Dinge zu Dokumentieren in denen diese Kommentare enthalten sind
-(z.B. in Crates, Modulen oder Funktionen) ansttat das zu kommentieren,
-was auf ihnen folgt.
+um Dinge zu dokumentieren in denen diese Kommentare enthalten sind
+(z.B. in Crates, Modulen oder Funktionen) anstatt das zu kommentieren,
+was nach ihnen folgt.
 Üblicherweise wird diese Form von Kommentar am Anfang einer
 Crate (lib.rs) oder eines Moduls (mod.rs) verwendet:
 

--- a/book/Primitive_Typen.md
+++ b/book/Primitive_Typen.md
@@ -4,7 +4,7 @@ Die Rust Programmiersprache hat eine Reihe von Typen die als "primitiv"
 angesehen werden. Das bedeutet, dass sie in die Sprache eingebaut sind.
 Rust ist so strukturiert, dass die Standardbibliothek auch eine Menge
 nützlicher Typen zur Verfügung stellt,
-auf welche die auf primitiven Typen aufbauen, aber diese hier sind am
+die auch auf primitiven Typen aufbauen, aber diese hier sind am
 "primitivsten".
 
 # Booleans

--- a/book/Primitive_Typen.md
+++ b/book/Primitive_Typen.md
@@ -4,7 +4,7 @@ Die Rust Programmiersprache hat eine Reihe von Typen die als "primitiv"
 angesehen werden. Das bedeutet, dass sie in die Sprache eingebaut sind.
 Rust ist so strukturiert, dass die Standardbibliothek auch eine Menge
 nützlicher Typen zur Verfügung stellt,
-auch welche die auf primitiven Typen aufbauen, aber diese hier sind am
+auf welche die auf primitiven Typen aufbauen, aber diese hier sind am
 "primitivsten".
 
 # Booleans
@@ -45,7 +45,7 @@ Du findest mehr Dokumentation zu `char`s
 
 [char]: https://doc.rust-lang.org/std/primitive.char.html
 
-# Numerische Type
+# Numerische Typen
 
 Rust hat eine Vielzahl an numerischen Typen in ein paar Kategorien:
 Vorzeichenbehaftet und Vorzeichenlos, feste und variable Größe,
@@ -53,9 +53,9 @@ Fließkomma- und Ganzzahl.
 
 Diese Typen bestehen aus zwei Teilen: Der Kategorie und ihrer Größe.
 Zum Beispiel ist `u16` ein vorzeichenloser Typ, der 16 bit groß ist.
-Mehr bits erlauben größere Zahlen.
+Mehr Bits erlauben größere Zahlen.
 
-Wenn ein Zahlenliteral keinen Typ durch etwas zugewiesen bekommt, dann
+Wenn ein Zahlenliteral keinen Typ explizit zugewiesen bekommt, dann
 sind das hier die Standards:
 
 ```rust
@@ -101,7 +101,7 @@ Also ist `u8` eine vorzeichenlose 8-bit Ganzzahl und
 ## Typen fester Größe
 
 Typen fester Größe enthalten eine speziefische Anzahl an Bits in
-ihrer Darstellung. Gültige Bitgrößen sind `8`, `16`, `32 und `64`.
+ihrer Darstellung. Gültige Bitgrößen sind `8`, `16`, `32` und `64`.
 Also ist `u32` eine vorzeichenlose Ganzzahl mit 32 Bits und
 `i64` eine vorzeichenbehaftete Ganzzahl mit 64 Bits.
 
@@ -124,7 +124,7 @@ let mut m = [1, 2, 3]; // m: [i32; 3]
 ```
 
 Arrays haben den Typ `[T; N]`. Wir werden über diese `T` Notation
-[im Generics Abschnitt][generics] rede. Das `N` ist eine Konstante zur
+[im Generics Abschnitt][generics] reden. Das `N` ist eine Konstante zur
 Kompilierzeit um die Länge des Arrays anzuzeigen.
 
 Es gibt eine abkürzende Schreibweise um jedes Element des Arrays mit dem
@@ -219,8 +219,8 @@ Wie du sehen kannst sehen kannst, sieht der Typ eins Tupels genaus aus wie
 das jeweilige Tupel, aber mit den jeweiligen Typen anstatt Werten.
 Aufmerksame Leser werden auch feststellen, dass Tupel heterogen sind:
 Wir haben ein `i32` und ein `&str` in diesem Tupel.
-(In Systemprogrammiersprachen sind Strings ein wenig Komplexer als in anderen
-Sprachen. Fürs erste lies `&str` als ein *string slice*.
+(In Systemprogrammiersprachen sind Strings ein wenig komplexer als in anderen
+Sprachen. Fürs Erste lies `&str` als ein *string slice*.
 Wir werden bald noch mehr darüber lernen.)
 
 Tupel können einander zugewiesen werden, wenn die enthaltenen Typen und
@@ -247,7 +247,7 @@ println!("x ist {}", x);
 
 Erinnerst du dich an [zuvor][let], als wir sagten, dass die linke Seite
 etwas mächtiger ist als einfach nur eine Variablenbindung zuzuweisen?
-Dabei sind wir nun. Wir können auf der linken Seite des `let` ein Muster
+Das ist ein Beispiel dafür. Wir können auf der linken Seite des `let` ein Muster
 verwenden und, wenn es zu der rechten Seite passt, mehrere Variablenbindungen
 gleichzeitig zuweisen. In diesem Fall "destrukturiert" `let` das Tupel bzw.
 "nimmt es auseinander" und bindet die Teilstücke an Variablen.

--- a/book/Schleifen.md
+++ b/book/Schleifen.md
@@ -40,7 +40,7 @@ while !done {
 wie häufig etwas wiederholt werden muss.
 
 Wenn du eine Endlosschleife benötigst,
-dann bist du vielleicht versucht das hier zu schreiben:
+dann bist du vielleicht dazu verleitet das hier zu schreiben:
 
 ```rust
 while true {
@@ -53,8 +53,8 @@ loop {
 ```
 
 Rusts Kontrollflussanalyse behandelt diese Konstrukt anders als `while true`,
-da es weis, dass die Schleife endlos ist. Allgemein gilt, dass, je mehr
-Informationen wir dem Compiler geben könenn, umso bessere Sicherheit und
+da es weiß, dass die Schleife endlos ist. Allgemein gilt, je mehr
+Informationen wir dem Compiler geben können, umso bessere Sicherheit und
 Code-Erzeugung erhalten wir. Deswegen solltest du immer `loop` vorziehen,
 falls du planst endlos zu iterieren.
 
@@ -103,7 +103,7 @@ Das obere Ende ist jedoch exklusiv, also gibt unsere Schleife nur
 
 Rust hat bewusst keine "C-Style" `for` Schleifen.
 Jedes Element der Schleife manuell zu kontrollieren ist kompliziert und
-Fehleranfällig, sogar für erfahrene C-Entwickler.
+fehleranfällig, sogar für erfahrene C-Entwickler.
 
 ### Enumerate
 
@@ -192,7 +192,7 @@ loop {
 ```
 
 Wir iterieren nun endlos und benutzen `break` um frühzeitig aus der Schleife
-auszubrechen. Eine explizitee `return` Anweisung würde die Schleife ebenso
+auszubrechen. Eine explizite `return` Anweisung würde die Schleife ebenso
 frühzeitig beenden.
 
 `continue` ist ähnlich, aber anstatt die Schleife zu beenden,


### PR DESCRIPTION
The usual corrections + added a missing ` to correct markdown syntax at some point.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rust-lang-de/rustbook-de/32)
<!-- Reviewable:end -->
