### PR TITLE
Konsolenausgabe formatieren

### DIFF
--- a/src/ch03-02-data-types.md
+++ b/src/ch03-02-data-types.md
@@ -22,7 +22,7 @@ Wenn wir diese Typ-Annotation nicht angeben, zeigt Rust den folgenden Fehler
 an, was bedeutet, dass der Kompilierer mehr Informationen von uns benötigt, um
 zu wissen welchen Typ wir verwenden wollen:
 
-```text
+```console
 $ cargo build
    Compiling no_type_annotations v0.1.0 (file:///projects/no_type_annotations)
 error[E0282]: type annotations needed
@@ -422,7 +422,7 @@ fn main() {
 
 Die Ausführung dieses Codes mit `cargo run` ergibt folgendes Ergebnis:
 
-```text
+```console
 $ cargo run
    Compiling arrays v0.1.0 (file:///projects/arrays)
     Finished dev [unoptimized + debuginfo] target(s) in 0.31s

--- a/src/ch03-03-how-functions-work.md
+++ b/src/ch03-03-how-functions-work.md
@@ -40,7 +40,7 @@ Lass uns ein neues Binärprojekt namens „functions“ anfangen, um Funktionen
 weiter zu erforschen. Platziere das Beispiel `another_function` in
 *src/main.rs* und lass es laufen. Du solltest die folgende Ausgabe sehen:
 
-```text
+```console
 $ cargo run
    Compiling functions v0.1.0 (file:///projects/functions)
     Finished dev [unoptimized + debuginfo] target(s) in 0.28s
@@ -82,7 +82,7 @@ fn another_function(x: i32) {
 Versuche, dieses Programm auszuführen; du solltest die folgende Ausgabe
 erhalten:
 
-```text
+```console
 $ cargo run
    Compiling functions v0.1.0 (file:///projects/functions)
     Finished dev [unoptimized + debuginfo] target(s) in 1.21s
@@ -125,7 +125,7 @@ Lass uns versuchen, diesen Code auszuführen. Ersetze das Programm, das sich
 derzeit in der Datei *src/main.rs* deines „functions“-Projekts befindet, durch
 das vorhergehende Beispiel und führe es mit `cargo run` aus:
 
-```text
+```console
 $ cargo run
    Compiling functions v0.1.0 (file:///projects/functions)
     Finished dev [unoptimized + debuginfo] target(s) in 0.31s
@@ -178,7 +178,7 @@ einen Fehler erhalten:
 
 <span class="filename">Dateiname: src/main.rs</span>
 
-```rust,ignore,does_not_compile
+```rust,does_not_compile
 fn main() {
     let x = (let y = 6);
 }
@@ -187,7 +187,7 @@ fn main() {
 
 Wenn du dieses Programm ausführst, wirst du in etwa folgenden Fehler erhalten:
 
-```text
+```console
 $ cargo run
    Compiling functions v0.1.0 (file:///projects/functions)
 error: expected expression, found statement (`let`)
@@ -229,7 +229,7 @@ fn main() {
 }
 ```
 
-Der Ausdruck:
+Der Ausdruck
 
 ```rust,ignore
 {
@@ -276,7 +276,7 @@ gültige Funktion in Rust. Beachte, dass der Rückgabetyp der Funktion ebenfalls
 angegeben ist, mit `-> i32`. Versuche diesen Code auszuführen; die Ausgabe
 sollte wie folgt aussehen:
 
-```text
+```console
 $ cargo run
    Compiling functions v0.1.0 (file:///projects/functions)
     Finished dev [unoptimized + debuginfo] target(s) in 0.30s
@@ -320,7 +320,7 @@ Ausdruck in eine Anweisung ändern, erhalten wir einen Fehler.
 
 <span class="filename">Dateiname: src/main.rs</span>
 
-```rust,ignore,does_not_compile
+```rust,does_not_compile
 fn main() {
     let x = plus_one(5);
 
@@ -334,7 +334,7 @@ fn plus_one(x: i32) -> i32 {
 
 Das Kompilieren dieses Codes führt zum folgenden Fehler:
 
-```text
+```console
 $ cargo run
    Compiling functions v0.1.0 (file:///projects/functions)
 error[E0308]: mismatched types

--- a/src/ch04-01-what-is-ownership.md
+++ b/src/ch04-01-what-is-ownership.md
@@ -377,7 +377,7 @@ nichts freigeben, wenn `s1` den Gültigkeitsbereich verlässt. Schau dir an, was
 passiert, wenn du versuchst, `s1` zu benutzen, nachdem `s2` erstellt wurde; es
 wird nicht funktionieren:
 
-```rust,ignore,does_not_compile
+```rust,does_not_compile
 let s1 = String::from("Hallo");
 let s2 = s1;
 
@@ -387,7 +387,7 @@ println!("{} Welt!", s1);
 Du erhältst eine Fehlermeldung wie diese, wodurch Rust dich daran hindert, die
 ungültige Referenz zu verwenden:
 
-```text
+```console
 $ cargo run
    Compiling ownership v0.1.0 (file:///projects/ownership)
 error[E0382]: borrow of moved value: `s1`

--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -102,7 +102,7 @@ ausleihen? Versuche den Code in Codeblock 4-6. Achtung: Es funktioniert nicht!
 
 <span class="filename">Dateiname: src/main.rs</span>
 
-```rust,ignore,does_not_compile
+```rust,does_not_compile
 fn main() {
     let s = String::from("Hallo");
 
@@ -119,7 +119,7 @@ verändern</span>
 
 Hier ist die Fehlermeldung:
 
-```text
+```console
 $ cargo run
    Compiling ownership v0.1.0 (file:///projects/ownership)
 error[E0596]: cannot borrow `*some_string` as mutable, as it is behind a `&` reference
@@ -171,7 +171,7 @@ Gültigkeitsbereich haben. Dieser Code wird fehlschlagen:
 
 <span class="filename">Dateiname: src/main.rs</span>
 
-```rust,ignore,does_not_compile
+```rust,does_not_compile
 let mut s = String::from("Hallo");
 
 let r1 = &mut s;
@@ -182,7 +182,7 @@ println!("{}, {}", r1, r2);
 
 Hier ist die Fehlermeldung:
 
-```text
+```console
 $ cargo run
    Compiling ownership v0.1.0 (file:///projects/ownership)
 error[E0499]: cannot borrow `s` as mutable more than once at a time
@@ -241,7 +241,7 @@ let r2 = &mut s;
 Eine ähnliche Regel gibt es für die Kombination von veränderlichen und
 unveränderlichen Referenzen. Dieser Code führt zu einem Fehler:
 
-```rust,ignore,does_not_compile
+```rust,does_not_compile
 let mut s = String::from("Hallo");
 
 let r1 = &s;     // kein Problem
@@ -253,7 +253,7 @@ println!("{}, {} und {}", r1, r2, r3);
 
 Hier ist die Fehlermeldung:
 
-```text
+```console
 $ cargo run
    Compiling ownership v0.1.0 (file:///projects/ownership)
 error[E0502]: cannot borrow `s` as mutable because it is also borrowed as immutable
@@ -327,7 +327,7 @@ Kompilierfehler verhindern wird:
 
 <span class="filename">Dateiname: src/main.rs</span>
 
-```rust,ignore,does_not_compile
+```rust,does_not_compile
 fn main() {
     let reference_to_nothing = dangle();
 }
@@ -341,7 +341,7 @@ fn dangle() -> &String {
 
 Hier ist die Fehlermeldung:
 
-```text
+```console
 $ cargo run
    Compiling ownership v0.1.0 (file:///projects/ownership)
 error[E0106]: missing lifetime specifier
@@ -373,7 +373,7 @@ Lass uns einen genaueren Blick auf das werfen, was in jeder Phase unseres
 
 <span class="filename">Dateiname: src/main.rs</span>
 
-```rust,ignore,does_not_compile
+```rust,does_not_compile
 # fn main() {
 #     let reference_to_nothing = dangle();
 # }

--- a/src/ch04-03-slices.md
+++ b/src/ch04-03-slices.md
@@ -48,7 +48,7 @@ Da wir den `String` Zeichen für Zeichen durchgehen und prüfen müssen, ob ein
 Wert ein Leerzeichen ist, wandeln wir unseren `String` mit der Methode
 `as_bytes` in ein Byte-Array um:
 
-```rust,ignore
+```rust
 # fn first_word(s: &String) -> usize {
     let bytes = s.as_bytes();
 #
@@ -67,7 +67,7 @@ Wert ein Leerzeichen ist, wandeln wir unseren `String` mit der Methode
 Als nächstes erstellen wir einen Iterator über das Byte-Array, indem wir die
 Methode `iter` verwenden:
 
-```rust,ignore
+```rust
 # fn first_word(s: &String) -> usize {
 #     let bytes = s.as_bytes();
 #
@@ -102,7 +102,7 @@ Innerhalb der `for`-Schleife suchen wir mit Hilfe der Byte-Literal-Syntax
 Leerzeichen finden, geben wir die Position zurück. Andernfalls geben wir die
 Länge der Zeichenkette zurück, indem wir `s.len()` verwenden:
 
-```rust,ignore
+```rust
 # fn first_word(s: &String) -> usize {
 #     let bytes = s.as_bytes();
 #
@@ -313,7 +313,7 @@ Kompilierfehler:
 
 <span class="filename">Dateiname: src/main.rs</span>
 
-```rust,ignore,does_not_compile
+```rust,does_not_compile
 # fn first_word(s: &String) -> &str {
 #     let bytes = s.as_bytes();
 #
@@ -339,7 +339,7 @@ fn main() {
 
 Hier ist der Kompilierfehler:
 
-```text
+```console
 $ cargo run
    Compiling ownership v0.1.0 (file:///projects/ownership)
 error[E0502]: cannot borrow `s` as mutable because it is also borrowed as immutable
@@ -399,7 +399,7 @@ Ein erfahrenerer Rust-Entwickler würde stattdessen die in Codeblock 4-9
 gezeigte Signatur schreiben, da sie es uns erlaubt, dieselbe Funktion sowohl
 auf `&String`-Werte als auch auf `&str`-Werte anzuwenden.
 
-```rust,ignore
+```rust
 fn first_word(s: &str) -> &str {
 #     let bytes = s.as_bytes();
 #

--- a/src/ch05-01-defining-structs.md
+++ b/src/ch05-01-defining-structs.md
@@ -308,7 +308,7 @@ Kapitel 10 besprechen.
 >
 > <span class="filename">Dateiname: src/main.rs</span>
 >
-> ```rust,ignore,does_not_compile
+> ```rust,does_not_compile
 > struct User {
 >     username: &str,
 >     email: &str,
@@ -328,7 +328,7 @@ Kapitel 10 besprechen.
 >
 > Der Compiler wird sich beschweren, dass die Lebensdauer nicht angegeben ist:
 >
-> ```text
+> ```console
 > $ cargo run
 >    Compiling structs v0.1.0 (file:///projects/structs)
 > error[E0106]: missing lifetime specifier

--- a/src/ch05-02-example-structs.md
+++ b/src/ch05-02-example-structs.md
@@ -35,7 +35,7 @@ durch separate Breiten- und Höhenvariablen beschrieben wird</span>
 
 Nun führe dieses Programm mit `cargo run` aus:
 
-```text
+```console
 $ cargo run
    Compiling structs v0.1.0 (file:///projects/structs)
     Finished dev [unoptimized + debuginfo] target(s) in 0.42s
@@ -50,7 +50,7 @@ Rechteck.
 
 Das Problem dieses Codes wird bei der Signatur von `area` deutlich:
 
-```rust,ignore
+```rust
 # fn main() {
 #     let width1 = 30;
 #     let height1 = 50;
@@ -176,7 +176,7 @@ Kapiteln verwendet haben. Dies wird jedoch nicht funktionieren.
 
 <span class="filename">Dateiname: src/main.rs</span>
 
-```rust,ignore,does_not_compile
+```rust,does_not_compile
 struct Rectangle {
     width: u32,
     height: u32,
@@ -271,7 +271,7 @@ fn main() {
 Wenn wir das Programm nun ausführen, werden wir keinen Fehler mehr erhalten und
 folgende Ausgabe sehen:
 
-```text
+```console
 $ cargo run
    Compiling structs v0.1.0 (file:///projects/structs)
     Finished dev [unoptimized + debuginfo] target(s) in 0.48s
@@ -285,7 +285,7 @@ Strukturen ist es hilfreich eine Ausgabe zu haben, die etwas leichter zu lesen
 ist. In diesen Fällen können wir `{:#?}` anstelle von `{:?}` in der
 `println!`-Meldung verwenden. Die Ausgabe sieht dann wie folgt aus:
 
-```text
+```console
 $ cargo run
    Compiling structs v0.1.0 (file:///projects/structs)
     Finished dev [unoptimized + debuginfo] target(s) in 0.48s

--- a/src/ch06-01-defining-an-enum.md
+++ b/src/ch06-01-defining-an-enum.md
@@ -395,7 +395,7 @@ verwenden als wäre es definitiv ein gültiger Wert. Beispielsweise lässt sich
 dieser Code nicht kompilieren, weil er versucht, ein `i8` mit einem
 `Option<i8>` zu addieren:
 
-```rust,ignore,does_not_compile
+```rust,does_not_compile
 let x: i8 = 5;
 let y: Option<i8> = Some(5);
 
@@ -404,7 +404,7 @@ let sum = x + y;
 
 Wenn wir diesen Code ausführen, erhalten wir eine Fehlermeldung wie diese:
 
-```text
+```console
 $ cargo run
    Compiling enums v0.1.0 (file:///projects/enums)
 error[E0277]: cannot add `std::option::Option<i8>` to `i8`

--- a/src/ch06-02-match.md
+++ b/src/ch06-02-match.md
@@ -263,7 +263,7 @@ Es gibt noch einen weiteren Aspekt von `match`, den wir diskutieren müssen.
 Betrachte folgende Version unserer Funktion `plus_one`, die einen Fehler hat
 und sich nicht kompilieren lässt:
 
-```rust,ignore,does_not_compile
+```rust,does_not_compile
 fn plus_one(x: Option<i32>) -> Option<i32> {
     match x {
         Some(i) => Some(i + 1),
@@ -280,7 +280,7 @@ verursachen. Glücklicherweise ist es ein Fehler, von dem Rust weiß, wie er
 zu lösen ist. Wenn wir versuchen, diesen Code zu kompilieren, werden wir
 diese Fehlermeldung bekommen:
 
-```text
+```console
 $ cargo run
    Compiling enums v0.1.0 (file:///projects/enums)
 error[E0004]: non-exhaustive patterns: `None` not covered

--- a/src/ch08-01-vectors.md
+++ b/src/ch08-01-vectors.md
@@ -171,7 +171,7 @@ haben kannst. Diese Regel trifft in Codeblock 8-7 zu, wo wir eine
 unveränderliche Referenz auf das erste Element in einem Vektor halten und
 versuchen, am Ende ein Element hinzuzufügen, was nicht funktionieren wird.
 
-```rust,ignore,does_not_compile
+```rust,does_not_compile
 let mut v = vec![1, 2, 3, 4, 5];
 
 let first = &v[0];
@@ -186,7 +186,7 @@ hinzuzufügen, während eine Referenz auf ein Element gehalten wird</span>
 
 Das Kompilieren dieses Codes führt zu folgendem Fehler:
 
-```text
+```console
 $ cargo run
    Compiling collections v0.1.0 (file:///projects/collections)
 error[E0502]: cannot borrow `v` as mutable because it is also borrowed as immutable

--- a/src/ch08-02-strings.md
+++ b/src/ch08-02-strings.md
@@ -275,7 +275,7 @@ jedoch in Rust versuchst, mittels Indexierungssyntax auf Teile einer
 Zeichenkette zuzugreifen, wirst du einen Fehler erhalten. Betrachte den
 ungültigen Code in Codeblock 8-19.
 
-```rust,ignore,does_not_compile
+```rust,does_not_compile
 let s1 = String::from("Hallo");
 let h = s1[0];
 
@@ -287,7 +287,7 @@ Zeichenkette zu verwenden</span>
 
 Dieser Code führt zu folgendem Fehler:
 
-```text
+```console
 $ cargo run
    Compiling collections v0.1.0 (file:///projects/collections)
 error[E0277]: the type `std::string::String` cannot be indexed by `{integer}`
@@ -337,7 +337,7 @@ Zeichenkette 2 Bytes Speicherplatz benötigt. Daher wird ein Index auf die Bytes
 der Zeichenkette nicht immer mit einem gültigen Unicode-Skalarwert korrelieren.
 Um das zu erläutern, betrachte diesen ungültigen Rust-Code:
 
-```rust,ignore,does_not_compile
+```rust,does_not_compile
 let hello = "Здравствуйте";
 let answer = &hello[0];
 
@@ -427,7 +427,7 @@ was bedeutet, dass `s` gleich `Зд` ist. Was würde passieren, wenn wir
 Laufzeit abbrechen, genauso als wenn mit einem ungültigen Index auf einen
 Vektor zugegriffen würde:
 
-```text
+```console
 $ cargo run
    Compiling collections v0.1.0 (file:///projects/collections)
     Finished dev [unoptimized + debuginfo] target(s) in 0.43s

--- a/src/ch09-01-unrecoverable-errors-with-panic.md
+++ b/src/ch09-01-unrecoverable-errors-with-panic.md
@@ -39,7 +39,7 @@ fn main() {
 
 Wenn du das Programm ausführst, wirst du in etwa das hier sehen:
 
-```text
+```console
 $ cargo run
    Compiling panic v0.1.0 (file:///projects/panic)
     Finished dev [unoptimized + debuginfo] target(s) in 0.25s
@@ -103,7 +103,7 @@ Versuch, ein Element an einem Index zu lesen, der nicht existiert, die
 Ausführung stoppen und die Fortsetzung verweigern. Versuchen wir es und sehen,
 was passiert:
 
-```text
+```console
 $ cargo run
    Compiling panic v0.1.0 (file:///projects/panic)
     Finished dev [unoptimized + debuginfo] target(s) in 0.27s
@@ -132,7 +132,7 @@ uns versuchen, eine Aufrufhistorie zu erhalten, indem wir die Umgebungsvariable
 `RUST_BACKTRACE` auf einen beliebigen Wert außer 0 setzen. Codeblock 9-2 zeigt
 eine Ausgabe, wie du sie in etwa sehen wirst.
 
-```text
+```console
 $ RUST_BACKTRACE=1 cargo run
 thread 'main' panicked at 'index out of bounds: the len is 3 but the index is 99', /rustc/5e1a799842ba6ed4a57e91f7ab9435947482f7d8/src/libcore/slice/mod.rs:2806:10
 stack backtrace:

--- a/src/ch09-02-recoverable-errors-with-result.md
+++ b/src/ch09-02-recoverable-errors-with-result.md
@@ -58,7 +58,7 @@ folgt ändern:
 
 [std-library-doc]: https://doc.rust-lang.org/std/index.html
 
-```rust,ignore,does_not_compile
+```rust,does_not_compile
 # use std::fs::File;
 #
 # fn main() {
@@ -71,7 +71,7 @@ folgt ändern:
 
 Der Versuch, zu kompilieren, liefert uns nun folgende Ausgabe:
 
-```text
+```console
 $ cargo run
    Compiling error-handling v0.1.0 (file:///projects/error-handling)
 error[E0308]: mismatched types
@@ -152,7 +152,7 @@ Makro `panic!` aufzurufen. Wenn es keine Datei namens *hallo.txt* in unserem
 aktuellen Verzeichnis gibt und wir diesen Code ausführen, sehen wir die
 folgende Ausgabe des Makros `panic!`:
 
-```text
+```console
 $ cargo run
    Compiling error-handling v0.1.0 (file:///projects/error-handling)
     Finished dev [unoptimized + debuginfo] target(s) in 0.73s
@@ -532,7 +532,7 @@ Der Teil von `match`, der den Rückgabetyp `Result` erfordert, ist
 Schauen wir uns an, was passiert, wenn wir den `?`-Operator in der Funktion
 `main` verwenden, die, wie du dich erinnern wirst, den Rückgabetyp `()` hat:
 
-```rust,ignore,does_not_compile
+```rust,does_not_compile
 use std::fs::File;
 
 fn main() {
@@ -542,7 +542,7 @@ fn main() {
 
 Wenn wir diesen Code kompilieren, erhalten wir folgende Fehlermeldung:
 
-```text
+```console
 $ cargo run
    Compiling error-handling v0.1.0 (file:///projects/error-handling)
 error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `std::ops::Try`)

--- a/src/ch10-01-syntax.md
+++ b/src/ch10-01-syntax.md
@@ -136,7 +136,7 @@ die generische Typparameter verwendet, aber noch nicht kompiliert</span>
 
 Wenn wir diesen Code kompilieren, erhalten wir diesen Fehler:
 
-```text
+```console
 $ cargo run
    Compiling chapter10 v0.1.0 (file:///projects/chapter10)
 error[E0369]: binary operation `>` cannot be applied to type `T`
@@ -228,7 +228,7 @@ Kompilierer wissen, dass der generische Typ `T` für diese Instanz von
 definiert haben, dass es den gleichen Typ wie `x` hat, erhalten wir einen
 Typfehler wie diesen:
 
-```text
+```console
 $ cargo run
    Compiling chapter10 v0.1.0 (file:///projects/chapter10)
 error[E0308]: mismatched types

--- a/src/ch10-02-traits.md
+++ b/src/ch10-02-traits.md
@@ -561,7 +561,7 @@ zurück, um die Definition der Funktion `largest`, die einen generischen
 Typparameter verwendet, zu korrigieren! Als wir das letzte Mal versuchten,
 den Code auszuführen, erhielten wir diesen Fehler:
 
-```text
+```console
 $ cargo run
    Compiling chapter10 v0.1.0 (file:///projects/chapter10)
 error[E0369]: binary operation `>` cannot be applied to type `T`
@@ -618,7 +618,7 @@ fn largest<T: PartialOrd>(list: &[T]) -> T {
 
 Wenn wir den Code kompilieren, erhalten wir nun andere Fehlermeldungen:
 
-```text
+```console
 $ cargo run
    Compiling chapter10 v0.1.0 (file:///projects/chapter10)
 error[E0508]: cannot move out of type `[T]`, a non-copy slice

--- a/src/ch10-03-lifetime-syntax.md
+++ b/src/ch10-03-lifetime-syntax.md
@@ -60,7 +60,7 @@ den Wert in `r` auszugeben. Dieser Code lässt sich nicht kompilieren, weil der
 Wert, auf den sich `r` bezieht, den Gültigkeitsbereich verlassen hat, bevor wir
 versuchen, ihn zu verwenden. Hier ist die Fehlermeldung:
 
-```text
+```console
 $ cargo run
    Compiling chapter10 v0.1.0 (file:///projects/chapter10)
 error[E0597]: `x` does not live long enough
@@ -219,7 +219,7 @@ noch nicht kompiliert</span>
 
 Stattdessen erhalten wir folgenden Fehler, der von Lebensdauern spricht:
 
-```text
+```console
 $ cargo run
    Compiling chapter10 v0.1.0 (file:///projects/chapter10)
 error[E0106]: missing lifetime specifier
@@ -433,7 +433,7 @@ nachdem `string2` den Gültigkeitsbereich verlassen hat</span>
 
 Wenn wir versuchen, diesen Code zu kompilieren, erhalten wir folgenden Fehler:
 
-```text
+```console
 $ cargo run
    Compiling chapter10 v0.1.0 (file:///projects/chapter10)
 error[E0597]: `string2` does not live long enough
@@ -535,7 +535,7 @@ angegeben haben, wird diese Implementierung nicht kompilieren, weil die
 Lebensdauer des Rückgabewerts überhaupt nicht mit der Lebensdauer der Parameter
 zusammenhängt. Hier ist die Fehlermeldung, die wir erhalten:
 
-```text
+```console
 $ cargo run
    Compiling chapter10 v0.1.0 (file:///projects/chapter10)
 error[E0515]: cannot return value referencing local variable `result`

--- a/src/ch11-01-writing-tests.md
+++ b/src/ch11-01-writing-tests.md
@@ -38,7 +38,7 @@ ist.
            
 Lass uns ein neues Bibliotheksprojekt namens `adder` erstellen:
 
-```text
+```console
 $ cargo new adder --lib
      Created library `adder` project
 $ cd adder
@@ -81,7 +81,7 @@ erfolgreich ist.
 Das Kommando `cargo test` führt alle Tests in unserem Projekt aus, wie in
 Codeblock 11-2 zu sehen ist.
 
-```text
+```console
 $ cargo test
    Compiling adder v0.1.0 (file:///projects/adder)
     Finished test [unoptimized + debuginfo] target(s) in 0.57s
@@ -154,7 +154,7 @@ mod tests {
 Dann führe `cargo test` erneut aus. Die Ausgabe zeigt nun `exploration`
 anstelle von `it_works`:
 
-```text
+```console
 $ cargo test
    Compiling adder v0.1.0 (file:///projects/adder)
     Finished test [unoptimized + debuginfo] target(s) in 0.59s
@@ -207,7 +207,7 @@ Führe die Tests erneut mit `cargo test` aus. Die Ausgabe sollte wie in
 Codeblock 11-4 aussehen, was zeigt, dass unser Test `exploration` bestanden und
 `another` fehlgeschlagen ist.
 
-```text
+```console
 $ cargo test
    Compiling adder v0.1.0 (file:///projects/adder)
     Finished test [unoptimized + debuginfo] target(s) in 0.72s
@@ -354,7 +354,7 @@ Makro `assert!` aufgerufen und ihm das Aufrufergebnis von
 `larger.can_hold(&smaller)` übergeben. Dieser Ausdruck soll `true` zurückgeben,
 also sollte unser Test erfolgreich sein. Lass es uns herausfinden!
 
-```text
+```console
 $ cargo test
    Compiling rectangle v0.1.0 (file:///projects/rectangle)
     Finished test [unoptimized + debuginfo] target(s) in 0.66s
@@ -432,7 +432,7 @@ müssen wir dieses Ergebnis negieren, bevor wir es an das Makro `assert!`
 übergeben. Als Ergebnis wird unser Test bestehen, wenn `can_hold` den
 Rückgabewert `false` hat:
 
-```text
+```console
 $ cargo test
    Compiling rectangle v0.1.0 (file:///projects/rectangle)
     Finished test [unoptimized + debuginfo] target(s) in 0.66s
@@ -509,7 +509,7 @@ impl Rectangle {
 
 Das Ausführen der Tests ergibt nun Folgendes:
 
-```text
+```console
 $ cargo test
    Compiling rectangle v0.1.0 (file:///projects/rectangle)
     Finished test [unoptimized + debuginfo] target(s) in 0.66s
@@ -582,7 +582,7 @@ Makro `assert_eq!`</span>
 
 Lass uns prüfen, ob sie den Test besteht!
 
-```text
+```console
 $ cargo test
    Compiling adder v0.1.0 (file:///projects/adder)
     Finished test [unoptimized + debuginfo] target(s) in 0.58s
@@ -629,7 +629,7 @@ pub fn add_two(a: i32) -> i32 {
 
 Führe die Tests erneut aus:
 
-```text
+```console
 $ cargo test
    Compiling adder v0.1.0 (file:///projects/adder)
     Finished test [unoptimized + debuginfo] target(s) in 0.61s
@@ -769,7 +769,7 @@ pub fn greeting(name: &str) -> String {
 
 Das Ausführen dieses Tests führt zu folgender Ausgabe:
 
-```text
+```console
 $ cargo test
    Compiling greeter v0.1.0 (file:///projects/greeter)
     Finished test [unoptimized + debuginfo] target(s) in 0.91s
@@ -824,7 +824,7 @@ der Funktion `greeting` erhalten haben:
 Wenn wir jetzt den Test ausführen, erhalten wir eine aussagekräftigere
 Fehlermeldung:
 
-```text
+```console
 $ cargo test
    Compiling greeter v0.1.0 (file:///projects/greeter)
     Finished test [unoptimized + debuginfo] target(s) in 0.93s
@@ -908,7 +908,7 @@ Wir setzen das Attribut `#[should_panic]` hinter das Attribut `#[test]` und vor
 die Testfunktion, auf die sie sich bezieht. Schauen wir uns das Ergebnis an,
 wenn dieser Test bestanden ist:
 
-```text
+```console
 $ cargo test
    Compiling guessing_game v0.1.0 (file:///projects/guessing_game)
     Finished test [unoptimized + debuginfo] target(s) in 0.58s
@@ -962,7 +962,7 @@ impl Guess {
 
 Wenn wir den Test in Codeblock 11-8 ausführen, wird er fehlschlagen:
 
-```text
+```console
 $ cargo test
    Compiling guessing_game v0.1.0 (file:///projects/guessing_game)
     Finished test [unoptimized + debuginfo] target(s) in 0.62s
@@ -1085,7 +1085,7 @@ vertauschen:
 
 Wenn wir diesmal den `should_panic`-Test ausführen, wird er fehlschlagen:
 
-```text
+```console
 $ cargo test
    Compiling guessing_game v0.1.0 (file:///projects/guessing_game)
     Finished test [unoptimized + debuginfo] target(s) in 0.66s


### PR DESCRIPTION
- Konsolenausgabe mit `console` statt `text` formatieren
- Rust-Code als ausführbar kennzeichnen, soweit sinnvoll (Flag `ignore` entfernen)

Übernimmt entsprechenden Pull Request https://github.com/rust-lang/book/pull/2352.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rust-lang-de/rustbook-de/97)
<!-- Reviewable:end -->
