### PR TITLE
"Kompilierer" nicht im Duden #116

### DIFF
--- a/src/appendix-03-derivable-traits.md
+++ b/src/appendix-03-derivable-traits.md
@@ -31,7 +31,7 @@ das die Formatierung für Endbenutzer übernimmt. Du solltest immer eine
 geeignete Art und Weise in Betracht ziehen, einen Typ für einen Endbenutzer
 anzuzeigen. Welche Teile des Typs sollte ein Endbenutzer sehen dürfen? Welche
 Teile würden sie für relevant halten? Welches Datenformat wäre für sie am
-relevantesten? Der Rust-Kompilierer verfügt nicht über dieses Wissen, sodass er
+relevantesten? Der Rust-Compiler verfügt nicht über dieses Wissen, sodass er
 kein angemessenes Standardverhalten für dich bereitstellen kann.
 
 Die Liste der ableitbaren Merkmale in diesem Anhang ist nicht vollständig:

--- a/src/appendix-04-useful-development-tools.md
+++ b/src/appendix-04-useful-development-tools.md
@@ -37,8 +37,8 @@ Dokumentation][rustfmt].
 ### Korrigiere deinen Code mit `rustfix`
 
 Das Werkzeug rustfix ist in Rust-Installationen enthalten und kann automatisch
-einige Kompilierer-Warnungen beheben. Wenn du Code in Rust geschrieben hast,
-hast du wahrscheinlich Kompilierer-Warnungen gesehen. Betrachte zum Beispiel
+einige Compiler-Warnungen beheben. Wenn du Code in Rust geschrieben hast,
+hast du wahrscheinlich Compiler-Warnungen gesehen. Betrachte zum Beispiel
 diesen Code:
 
 <span class="filename">Dateiname: src/main.rs</span>

--- a/src/appendix-05-editions.md
+++ b/src/appendix-05-editions.md
@@ -4,7 +4,7 @@ In Kapitel 1 hast du gesehen, dass `cargo new` Metadaten zur Ausgabe (edition)
 in deiner Datei *Cargo.toml* hinzufügt. Dieser Anhang erläutert, was das
 bedeutet!
 
-Die Sprache Rust und der Kompilierer haben einen sechswöchigen
+Die Sprache Rust und der Compiler haben einen sechswöchigen
 Veröffentlichungs-Zyklus, was bedeutet, dass die Nutzer einen konstanten Strom
 neuer Funktionen erhalten. Andere Programmiersprachen geben weniger oft größere
 Änderungen heraus; Rust gibt häufiger kleinere Aktualisierungen heraus. Nach
@@ -33,7 +33,7 @@ Zum Verfassungszeitpunkt dieses Artikels sind zwei Rust-Ausgaben verfügbar:
 Rust 2015 und Rust 2018. Dieses Buch wurde unter Verwendung der Rust-Ausgabe
 2018 geschrieben.
 
-Der Schlüssel `edition` in *Cargo.toml* gibt an, welche Ausgabe der Kompilierer
+Der Schlüssel `edition` in *Cargo.toml* gibt an, welche Ausgabe der Compiler
 für deinen Code verwenden soll. Wenn der Schlüssel nicht existiert, verwendet
 Rust aus Gründen der Abwärtskompatibilität die Edition `2015`.
 
@@ -42,12 +42,12 @@ Jedes Projekt kann sich für eine Ausgabe abweichend von der Standardausgabe
 Aufnahme eines neuen Schlüsselworts, das mit Bezeichnern im Code in Konflikt
 steht. Selbst wenn du dich nicht für diese Änderungen entscheidest, wird dein
 Code weiterhin kompilieren, auch wenn du die verwendete
-Rust-Kompilierer-Version aktualisierst.
+Rust-Compiler-Version aktualisierst.
 
-Alle Rust-Kompilierer-Versionen unterstützen jede Ausgabe, die vor der
-Veröffentlichung dieses Kompilierers existierte, und es können Kisten (crates)
+Alle Rust-Compiler-Versionen unterstützen jede Ausgabe, die vor der
+Veröffentlichung dieses Compilers existierte, und es können Kisten (crates)
 aller unterstützten Ausgaben miteinander verknüpft werden. Ausgabenänderungen
-wirken sich nur auf die Art und Weise aus, wie der Kompilierer anfangs den Code
+wirken sich nur auf die Art und Weise aus, wie der Compiler anfangs den Code
 analysiert. Wenn du also Rust 2015 verwendest und eine deiner Abhängigkeiten
 Rust 2018 verwendet, wird dein Projekt diese Abhängigkeit kompilieren und
 nutzen können. Die umgekehrte Situation, in der dein Projekt Rust 2018

--- a/src/appendix-07-nightly-rust.md
+++ b/src/appendix-07-nightly-rust.md
@@ -204,7 +204,7 @@ Jeder kann RFCs zur Verbesserung von Rust schreiben und die Vorschläge werden
 vom Rust-Team, das aus vielen thematischen Unterteams besteht, geprüft und
 diskutiert. Es gibt eine vollständige Liste der Teams auf der
 [Rust-Website][rust-website], in der die Teams für jeden Projektbereich
-aufgeführt sind: Sprachdesign, Kompilierer-Implementierung, Infrastruktur,
+aufgeführt sind: Sprachdesign, Compiler-Implementierung, Infrastruktur,
 Dokumentation und weitere. Das zuständige Team liest den Vorschlag und die
 Kommentare, schreibt einige eigene Kommentare und schließlich gibt es einen
 Konsens, die Funktionalität anzunehmen oder abzulehnen.

--- a/src/ch00-00-introduction.md
+++ b/src/ch00-00-introduction.md
@@ -21,9 +21,9 @@ Entwicklerteams mit unterschiedlichem Kenntnisstand in der
 Systemprogrammierung. Systemnaher Code ist anfällig für eine Vielzahl subtiler
 Fehler, die in den meisten anderen Sprachen nur durch ausgiebige Tests und
 sorgfältige Überprüfung des Codes durch erfahrene Entwickler erkannt werden
-können. In Rust spielt der Kompilierer eine Art Pförtnerrolle, indem er Code
+können. In Rust spielt der Compiler eine Art Pförtnerrolle, indem er Code
 mit diesen schwer fassbaren Fehlern verweigert zu kompilieren, darunter auch
-Nebenläufigkeitsfehler. Mit der Arbeit an der Seite des Kompilierers kann sich
+Nebenläufigkeitsfehler. Mit der Arbeit an der Seite des Compilers kann sich
 das Team auf die Programmlogik konzentrieren anstatt Fehler zu suchen.
 
 Rust bringt auch zeitgemäße Entwicklerwerkzeuge in die Welt der
@@ -68,7 +68,7 @@ wenn du zur Programmiersprache Rust beiträgst.
 Rust ist für Menschen, die sich nach Schnelligkeit und Stabilität einer Sprache
 sehnen. Unter Geschwindigkeit verstehen wir die Geschwindigkeit der Programme,
 die du mit Rust schreiben kannst, und die Geschwindigkeit, mit der dich Rust
-diese Programme schreiben lässt. Die Prüfungen des Rust-Kompilierers
+diese Programme schreiben lässt. Die Prüfungen des Rust-Compilers
 gewährleisten Stabilität während du neue Funktionen hinzufügst und deinen Code
 änderst. Dies steht im Gegensatz zu brüchigen Code-Altlasten in Sprachen ohne
 diese Prüfungen, die Entwickler oft scheuen modifizieren zu müssen. Durch das
@@ -178,9 +178,9 @@ du irritiert bist. Aber tue was immer für dich passt.
 <span id="ferris"></span>
 
 Ein wichtiger Teil beim Lernen von Rust ist das Verstehen der Fehlermeldungen,
-die der Kompilierer anzeigt: Diese leiten dich zum funktionierenden Code. Daher
+die der Compiler anzeigt: Diese leiten dich zum funktionierenden Code. Daher
 werden wir viele Beispiele bringen, die nicht kompilieren, zusammen mit der
-jeweiligen Fehlermeldung des Kompilierers. Wenn du also ein zufälliges Beispiel
+jeweiligen Fehlermeldung des Compilers. Wenn du also ein zufälliges Beispiel
 eingibst und ausführen willst, lässt es sich möglicherweise nicht kompilieren!
 Stelle sicher, dass du den umgebenden Text liest, um zu wissen, ob das
 Beispiel, das du ausführen willst, für einen Fehler gedacht ist. Ferris gibt

--- a/src/ch01-01-installation.md
+++ b/src/ch01-01-installation.md
@@ -11,7 +11,7 @@ benötigen.
 > nach anderen Möglichkeiten.
 
 Die folgenden Schritte installieren die neueste stabile Version des
-Rust-Kompilierers. Rust garantiert Stabilität und stellt somit sicher,
+Rust-Compilers. Rust garantiert Stabilität und stellt somit sicher,
 dass alle kompilierbaren Beispiele in diesem Buch auch mit neueren
 Rust-Versionen kompilierbar bleiben werden. Die Konsolenausgabe
 der Beispiele kann sich zwischen Versionen leicht unterscheiden,
@@ -53,10 +53,10 @@ ist bereits einer installiert, aber falls du versuchst, ein Rust-Programm
 zu kompilieren und du dabei eine Fehlermeldung erhältst, dass ein
 Programmbinder nicht ausgeführt werden konnte, dann bedeutet das, dass
 kein Programmbinder auf deinem Rechner installiert ist und du das
-nachholen musst. C-Kompilierer haben normalerweise den passenden Programmbinder
+nachholen musst. C-Compiler haben normalerweise den passenden Programmbinder
 dabei. Schau in der Dokumentation deines Betriebssystems nach, wie du einen
-C-Kompilierer installieren kannst. Auch bestehen einige verbreitete Rust-Pakete
-aus C-Code und benötigen einen C-Kompilierer. Deshalb kann es sinnvoll sein,
+C-Compiler installieren kannst. Auch bestehen einige verbreitete Rust-Pakete
+aus C-Code und benötigen einen C-Compiler. Deshalb kann es sinnvoll sein,
 bereits jetzt einen zu installieren.
 
 ### Die Installation von `rustup` in Windows

--- a/src/ch03-02-data-types.md
+++ b/src/ch03-02-data-types.md
@@ -7,7 +7,7 @@ Verbund.
 
 Denk daran, dass Rust eine *statisch typisierte* Sprache ist, was bedeutet,
 dass es die Typen von allen Variablen zur Kompilierzeit kennen muss. Der
-Kompilierer kann normalerweise auf der Grundlage des Wertes und wie wir ihn
+Compiler kann normalerweise auf der Grundlage des Wertes und wie wir ihn
 verwenden ableiten, welchen Typ wir verwenden wollen. Wenn mehrere Typen
 möglich sind, wie zum Beispiel als wir im Abschnitt [„Vergleich der Vermutung
 mit der Geheimzahl“][comparing-the-guess-to-the-secret-number] eine
@@ -19,7 +19,7 @@ let guess: u32 = "42".parse().expect("Keine Zahl!");
 ```
 
 Wenn wir diese Typ-Annotation nicht angeben, zeigt Rust den folgenden Fehler
-an, was bedeutet, dass der Kompilierer mehr Informationen von uns benötigt, um
+an, was bedeutet, dass der Compiler mehr Informationen von uns benötigt, um
 zu wissen welchen Typ wir verwenden wollen:
 
 ```console

--- a/src/ch03-03-how-functions-work.md
+++ b/src/ch03-03-how-functions-work.md
@@ -25,7 +25,7 @@ fn another_function() {
 ```
 
 Funktionsdefinitionen in Rust beginnen mit `fn` und haben einen Satz Klammern
-nach dem Funktionsnamen. Die geschweiften Klammern teilen dem Kompilierer mit,
+nach dem Funktionsnamen. Die geschweiften Klammern teilen dem Compiler mit,
 wo der Funktionsrumpf beginnt und endet.
 
 Wir können jede Funktion, die wir definiert haben, aufrufen, indem wir ihren
@@ -97,7 +97,7 @@ Klammern in der Formatierungszeichenkette befand.
 
 In Funktionssignaturen *musst* du den Typ jedes Parameters deklarieren. Dies
 ist eine bewusste Designentscheidung von Rust: Das Erfordernis von
-Typ-Annotationen in Funktionsdefinitionen bedeutet, dass der Kompilierer sie
+Typ-Annotationen in Funktionsdefinitionen bedeutet, dass der Compiler sie
 fast nie an anderer Stelle im Code benötigt, um herauszufinden, was du meinst.
 
 Wenn eine Funktion mehrere Parameter haben soll, trenne die

--- a/src/ch03-04-comments.md
+++ b/src/ch03-04-comments.md
@@ -2,7 +2,7 @@
 
 Alle Programmierer bemühen sich, ihren Code leicht verständlich zu machen, aber
 manchmal sind zusätzliche Erklärungen angebracht. In solchen Fällen versehen
-Entwickler den Quellcode mit *Kommentaren*, welche der Kompilierer ignoriert
+Entwickler den Quellcode mit *Kommentaren*, welche der Compiler ignoriert
 und für andere Entwickler nützlich sein können.
 
 Dies ist ein einfacher Kommentar:

--- a/src/ch04-01-what-is-ownership.md
+++ b/src/ch04-01-what-is-ownership.md
@@ -10,7 +10,7 @@ Speicherbereinigung, die während der Programmausführung ständig nach nicht me
 genutztem Speicher sucht. Bei anderen Sprachen muss der Programmierer selbst
 den Speicher explizit reservieren und freigeben. Rust verwendet einen dritten
 Ansatz: Der Speicher wird durch ein System aus Eigentümerschaft und einer Reihe
-von Regeln verwaltet, die der Kompilierer zur Kompilierzeit überprüft. Keine
+von Regeln verwaltet, die der Compiler zur Kompilierzeit überprüft. Keine
 der Eigentümerschaftsfunktionalitäten verlangsamt dein Programm, während es
 läuft.
 

--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -306,7 +306,7 @@ veränderliche Referenz `r3` erstellt wird. Diese Gültigkeitsbereiche
 überschneiden sich nicht, daher ist dieser Code zulässig.
 
 Auch wenn das Ausleihen von Fehlern manchmal frustrierend sein kann, denke
-daran, dass es der Rust-Kompilierer ist, der frühzeitig (zur Kompilierzeit und
+daran, dass es der Rust-Compiler ist, der frühzeitig (zur Kompilierzeit und
 nicht zur Laufzeit) auf einen möglichen Fehler hinweist und dir genau zeigt, wo
 das Problem liegt. Dann musst du nicht aufspüren, warum deine Daten nicht so
 sind, wie du dachtest.
@@ -317,9 +317,9 @@ In Sprachen mit Zeigern ist es leicht, fälschlicherweise einen *hängenden
 Zeiger* (dangling pointer) zu erzeugen, also einen Zeiger, der auf eine Stelle
 im Speicher verweist, die vielleicht an jemand anderem vergeben wurde, weil der
 Speicher freigegeben wurde, während noch ein Zeiger auf diesen Speicher
-bestehen bleibt. In Rust hingegen garantiert der Kompilierer, dass Referenzen
+bestehen bleibt. In Rust hingegen garantiert der Compiler, dass Referenzen
 niemals hängende Referenzen sein können: Wenn du eine Referenz auf Daten hast,
-stellt der Kompilierer sicher, dass die Daten nicht den Gültigkeitsbereich
+stellt der Compiler sicher, dass die Daten nicht den Gültigkeitsbereich
 verlassen, bevor die Referenz auf die Daten dies tut.
 
 Versuchen wir, eine hängende Referenz zu erstellen, was Rust mit einem

--- a/src/ch04-03-slices.md
+++ b/src/ch04-03-slices.md
@@ -300,7 +300,7 @@ fn second_word(s: &String) -> &str {
 ```
 
 Wir haben jetzt eine einfache API, die viel schwieriger durcheinanderzubringen
-ist, weil der Kompilierer sicherstellt, dass die Referenzen auf den `String`
+ist, weil der Compiler sicherstellt, dass die Referenzen auf den `String`
 gültig bleiben. Erinnere dich an den Fehler im Programm in Codeblock 4-8, als
 wir den Index bis zum Ende des ersten Wortes erhielten, dann aber die
 Zeichenkette löschten, sodass unser Index ungültig wurde. Dieser Code war

--- a/src/ch06-01-defining-an-enum.md
+++ b/src/ch06-01-defining-an-enum.md
@@ -310,7 +310,7 @@ Fallstudie zu `Option`, einer weiteren Aufzählung, die von der
 Standardbibliothek definiert wird. Der Typ `Option` wird an vielen Stellen
 verwendet, weil er das sehr häufige Szenario abbildet, in dem ein Wert etwas
 oder nichts sein könnte. Im Sinne des Typsystems bedeutet das, dass der
-Kompilierer überprüfen kann, ob du alle Fälle behandelt hast, die du behandelt
+Compiler überprüfen kann, ob du alle Fälle behandelt hast, die du behandelt
 sollst. Diese Funktionalität kann Fehler vermeiden, die in anderen
 Programmiersprachen extrem häufig auftreten.
 
@@ -328,7 +328,7 @@ Tony Hoare, der Erfinder von null, folgendes gesagt:
 > erste umfangreiche Typsystem für Referenzen in einer objektorientierten
 > Sprache. Mein Ziel war es, sicherzustellen, dass jede Verwendung von
 > Referenzen absolut sicher sein sollte, wobei die Überprüfung automatisch
-> durch den Kompilierer durchgeführt wird. Aber ich konnte der Versuchung nicht
+> durch den Compiler durchgeführt wird. Aber ich konnte der Versuchung nicht
 > widerstehen, eine Nullreferenz einzuführen, nur weil sie so einfach
 > umzusetzen war. Dies hat zu unzähligen Fehlern, Schwachstellen und
 > Systemabstürzen geführt, die in den letzten vierzig Jahren wahrscheinlich
@@ -390,7 +390,7 @@ bedeutet das in gewisser Weise dasselbe wie Null: Wir haben keinen gültigen
 Wert. Warum ist nun besser `Option<T>` anstelle von Null zu verwenden?
 
 Kurz gesagt, weil `Option<T>` und `T` (wobei `T` ein beliebiger Typ sein kann)
-unterschiedliche Typen sind, erlaubt es der Kompilierer nicht `Option<T>` so zu
+unterschiedliche Typen sind, erlaubt es der Compiler nicht `Option<T>` so zu
 verwenden als wäre es definitiv ein gültiger Wert. Beispielsweise lässt sich
 dieser Code nicht kompilieren, weil er versucht, ein `i8` mit einem
 `Option<i8>` zu addieren:
@@ -426,11 +426,11 @@ To learn more, run the command again with --verbose.
 Stark! Tatsächlich bedeutet diese Fehlermeldung, dass Rust nicht versteht, wie
 man ein `i8` und eine `Option<i8>` addiert, da es sich um unterschiedliche Typen
 handelt. Wenn wir einen Wert eines Typs wie `i8` in Rust haben, stellt der
-Kompilierer sicher, dass wir immer einen gültigen Wert haben. Wir können mit
+Compiler sicher, dass wir immer einen gültigen Wert haben. Wir können mit
 Zuversicht vorgehen, ohne vor der Verwendung dieses Wertes auf Null prüfen zu
 müssen. Nur wenn wir eine `Option<i8>` (oder einen anderen Werttyp) haben,
 müssen wir befürchten, dass wir möglicherweise keinen Wert haben, und der
-Kompilierer wird sicherstellen, dass wir diesen Fall behandeln, bevor wir den
+Compiler wird sicherstellen, dass wir diesen Fall behandeln, bevor wir den
 Wert verwenden.
 
 Mit anderen Worten musst du eine `Option<T>` in ein `T` konvertieren, bevor du

--- a/src/ch06-02-match.md
+++ b/src/ch06-02-match.md
@@ -6,7 +6,7 @@ abzugleichen und dann Code zum jeweils passenden Muster auszuführen. Muster
 können sich aus Literalen, Variablennamen, Platzhaltern und vielen anderen
 Dingen zusammensetzen. Kapitel 18 befasst sich mit all den verschiedenen
 Musterarten und wie sie funktionieren. Die Mächtigkeit von `match` kommt von
-der Ausdruckskraft der Muster und der Tatsache, dass der Kompilierer
+der Ausdruckskraft der Muster und der Tatsache, dass der Compiler
 sicherstellt, dass alle möglichen Fälle behandelt werden.
 
 Stelle dir einen `match`-Ausdruck wie eine Münzsortiermaschine vor:  Die Münzen

--- a/src/ch06-03-if-let.md
+++ b/src/ch06-03-if-let.md
@@ -124,7 +124,7 @@ behandeln musst.
 
 Deine Rust-Programme können nun Konzepte in deiner Domäne mit Hilfe von
 Strukturen und Aufzählungen ausdrücken. Das Erstellen benutzerdefinierter Typen
-zur Verwendung in deiner API gewährleistet Typsicherheit: Der Kompilierer wird
+zur Verwendung in deiner API gewährleistet Typsicherheit: Der Compiler wird
 sicherstellen, dass deine Funktionen nur Werte jenes Typs erhalten, den die
 Funktion erwartet.
 

--- a/src/ch07-00-managing-growing-projects-with-packages-crates-and-modules.md
+++ b/src/ch07-00-managing-growing-projects-with-packages-crates-and-modules.md
@@ -31,7 +31,7 @@ muss, zu begrenzen.
 Ein verwandtes Konzept ist der Gültigkeitsbereich (scope): Der verschachtelte
 Kontext, in dem Code geschrieben wird, hat eine Reihe von Namen, die als „im
 Gültigkeitsbereich“ (in scope) definiert sind. Beim Lesen, Schreiben und
-Kompilieren von Code müssen Programmierer und Kompilierer wissen, ob sich ein
+Kompilieren von Code müssen Programmierer und Compiler wissen, ob sich ein
 bestimmter Name an einer bestimmten Stelle auf eine Variable, Funktion,
 Struktur (struct), Aufzählung (enum), Modul, Konstante oder ein anderes Element
 bezieht und was dieses Element bedeutet. Du kannst Gültigkeitsbereiche

--- a/src/ch07-01-packages-and-crates.md
+++ b/src/ch07-01-packages-and-crates.md
@@ -3,7 +3,7 @@
 Die ersten Bestandteile des Modulsystems, die wir behandeln werden, sind Pakete
 (packages) und Kisten (crates). Eine Kiste ist eine Binärdatei oder eine
 Bibliothek. Die *Kistenwurzel* (crate root) ist eine Quelldatei, bei der der
-Rust-Kompilierer anfängt und die das Wurzelmodul deiner Kiste darstellt (Module
+Rust-Compiler anfängt und die das Wurzelmodul deiner Kiste darstellt (Module
 werden im Abschnitt [„Mit Modulen den Kontrollumfang und Datenschutz
 steuern“][modules] ausführlich erklärt). Ein *Paket* besteht aus einer oder
 mehreren Kisten, die eine Reihe von Funktionalitäten bereitstellen. Ein Paket
@@ -59,7 +59,7 @@ Zum Beispiel bietet die Kiste `rand` ein Merkmal (trait) namens `Rng`. Wir
 können auch eine Struktur (struct) mit dem Namen `Rng` in unserer eigenen Kiste
 definieren. Da die Funktionalität einer Kiste im Namensraum des eigenen
 Gültigkeitsbereichs ist, können wir `rand` als Abhängigkeit hinzufügen, ohne
-dadurch den Kompilierer durcheinanderzubringen, worauf sich der Name `Rng`
+dadurch den Compiler durcheinanderzubringen, worauf sich der Name `Rng`
 bezieht. In unserer Kiste bezieht er sich auf `struct Rng`, die wir definiert
 haben. Wir würden auf das Merkmal `Rng` aus der Kiste `rand` mit `rand::Rng`
 zugreifen.

--- a/src/ch08-02-strings.md
+++ b/src/ch08-02-strings.md
@@ -221,7 +221,7 @@ warte &ndash; der Typ von `&s2` ist `&String`, nicht `&str`, wie im zweiten
 Parameter von `add` spezifiziert. Warum kompiliert also Codeblock 8-18?
 
 Der Grund, warum wir `&s2` im Aufruf von `add` verwenden können, ist, dass der
-Kompilierer das Argument `&String` in einen `&str` umwandeln (coerce) kann.
+Compiler das Argument `&String` in einen `&str` umwandeln (coerce) kann.
 Wenn wir die Methode `add` aufrufen, benutzt Rust eine *automatische
 Umwandlung* (deref coercion), die hier `&s2` in `&s2[...]` umwandelt. Auf die
 automatische Umwandlung werden wir in Kapitel 15 tiefer eingehen. Da `add`

--- a/src/ch09-02-recoverable-errors-with-result.md
+++ b/src/ch09-02-recoverable-errors-with-result.md
@@ -50,7 +50,7 @@ Woher wissen wir, dass `File::open` ein `Result` zurückgibt? Wir könnten uns
 die [Standard-Bibliotheks-API-Dokumentation][std-library-doc] ansehen oder wir
 könnten den Compiler fragen! Wenn wir `f` eine Typ-Annotation geben, von der
 wir wissen, dass sie *nicht* der Rückgabetyp der Funktion ist, und dann
-versuchen, den Code zu kompilieren, wird der Kompilierer uns sagen, dass die
+versuchen, den Code zu kompilieren, wird der Compiler uns sagen, dass die
 Typen nicht übereinstimmen. Die Fehlermeldung sagt uns dann, welchen Typ `f`
 tatsächlich hat. Versuchen wir es! Wir wissen, dass der Rückgabetyp von
 `File::open` nicht vom Typ `u32` ist, also lass uns die Anweisung `let f` wie

--- a/src/ch09-03-to-panic-or-not-to-panic.md
+++ b/src/ch09-03-to-panic-or-not-to-panic.md
@@ -18,7 +18,7 @@ fehlschlagen könnte.
 In seltenen Situationen ist es besser, Code zu schreiben, der das Programm
 abbricht, anstatt ein `Result` zurückzugeben. Lass uns untersuchen, warum es
 bei Beispielen, Code-Prototypen und Tests angebracht ist, das Programm
-abzubrechen. Dann werden wir Situationen besprechen, in denen der Kompilierer
+abzubrechen. Dann werden wir Situationen besprechen, in denen der Compiler
 nicht feststellen kann, dass ein Fehler unmöglich ist, du als Mensch aber
 schon. Das Kapitel schließt mit einigen allgemeinen Richtlinien zur
 Entscheidung, ob in Bibliothekscode ein Programm abgebrochen werden soll.
@@ -42,11 +42,11 @@ gesamte Test fehlschlägt, auch wenn diese Methode nicht die zu testende
 Funktionalität ist. Da ein Test mit `panic!` als fehlgeschlagen markiert wird,
 ist der Aufruf von `unwrap` und `expect` genau das, was passieren sollte.
 
-### Fälle, in denen du mehr Informationen als der Kompilierer hast
+### Fälle, in denen du mehr Informationen als der Compiler hast
 
 Es wäre auch angemessen, `unwrap` aufzurufen, wenn du eine andere Logik hast,
 die sicherstellt, dass `Result` einen `Ok`-Wert hat, aber die Logik kann vom
-Kompilierer nicht verstanden werden. Du wirst immer noch ein `Result` haben,
+Compiler nicht verstanden werden. Du wirst immer noch ein `Result` haben,
 mit dem du umgehen musst: Welche Operation auch immer du aufrufst, es besteht
 immer noch die Möglichkeit, dass sie im Allgemeinen scheitert, auch wenn es in
 deiner speziellen Situation logischerweise unmöglich ist. Wenn du durch
@@ -64,9 +64,9 @@ Wir erstellen eine `IpAddr`-Instanz, indem wir eine hartkodierte Zeichenkette
 parsen. Wir können sehen, dass `127.0.0.1` eine gültige IP-Adresse ist, sodass
 es akzeptabel ist, hier `unwrap` zu verwenden. Eine hartkodierte, gültige
 Zeichenkette ändert jedoch nicht den Rückgabetyp der `parse`-Methode: Wir
-erhalten immer noch einen `Result`-Wert und der Kompilierer wird von uns
+erhalten immer noch einen `Result`-Wert und der Compiler wird von uns
 verlangen, `Result` so zu behandeln, als ob die `Err`-Variante möglich wäre,
-weil der Kompilierer nicht klug genug ist, um zu erkennen, dass diese
+weil der Compiler nicht klug genug ist, um zu erkennen, dass diese
 Zeichenkette stets eine gültige IP-Adresse ist. Wenn die
 IP-Adressen-Zeichenkette von einem Benutzer kam, anstatt fest im Programm
 kodiert zu sein, und daher möglicherweise fehlschlagen könnte, würden wir
@@ -122,9 +122,9 @@ insbesondere wenn deren Verletzung zu einem Programmabbruch führt.
 
 Zahlreiche Fehlerprüfungen in deinen Funktionen wären jedoch langatmig und
 störend. Glücklicherweise kannst du das Typsystem von Rust (und damit die
-Typprüfung durch den Kompilierer) verwenden, um viele Prüfungen für dich zu
+Typprüfung durch den Compiler) verwenden, um viele Prüfungen für dich zu
 übernehmen. Wenn deine Funktion einen besonderen Typ als Parameter hat, kannst
-du mit der Logik deines Codes fortfahren, da du weißt, dass der Kompilierer
+du mit der Logik deines Codes fortfahren, da du weißt, dass der Compiler
 bereits sichergestellt hat, dass du einen gültigen Wert hast. Wenn du zum
 Beispiel einen Typ anstatt einer `Option` hast, erwartet dein Programm *etwas*
 statt *nichts*. Dein Code muss dann nicht zwei Fälle für die Varianten `Some`

--- a/src/ch10-00-generics.md
+++ b/src/ch10-00-generics.md
@@ -31,9 +31,9 @@ kombinieren, um einen generischen Typ auf solche Typen einzuschränken, die ein
 bestimmtes Verhalten aufweisen, im Gegensatz zu einem beliebigen Typ.
 
 Schließlich werden wir die *Lebensdauer* (lifetimes) besprechen, eine Spielart
-generischer Typen, die dem Kompilierer Informationen darüber gibt, wie
+generischer Typen, die dem Compiler Informationen darüber gibt, wie
 Referenzen zueinander in Beziehung stehen. Die Lebensdauer erlaubt es uns, in
-vielen Situationen Werte auszuleihen und gleichzeitig dem Kompilierer die
+vielen Situationen Werte auszuleihen und gleichzeitig dem Compiler die
 Möglichkeit zu geben, die Gültigkeit der Referenzen zu überprüfen.
 
 ## Duplikate entfernen durch Extrahieren einer Funktion

--- a/src/ch10-01-syntax.md
+++ b/src/ch10-01-syntax.md
@@ -80,7 +80,7 @@ Rusts Typbezeichnungskonvention verwendet Binnenmajuskel (CamelCase). Als
 Abkürzung für „Typ“ ist `T` die Standardwahl der meisten Rust-Programmierer.
 
 Wenn wir einen Parameter im Funktionsrumpf verwenden, müssen wir den
-Parameternamen in der Signatur deklarieren, damit der Kompilierer weiß, was
+Parameternamen in der Signatur deklarieren, damit der Compiler weiß, was
 dieser Name bedeutet. In ähnlicher Weise müssen wir den Typ-Parameternamen
 deklarieren, bevor wir ihn in einer Funktionssignatur verwenden können. Um die
 generische Funktion `largest` zu definieren, platzieren wir die
@@ -223,7 +223,7 @@ fn main() {
 gleichen Typ sein, da beide den gleichen generischen Datentyp `T` haben.</span>
 
 Wenn wir in diesem Beispiel `x` den Integer-Wert 5 zuweisen, lassen wir den
-Kompilierer wissen, dass der generische Typ `T` für diese Instanz von
+Compiler wissen, dass der generische Typ `T` für diese Instanz von
 `Point<T>` ein Integer sein wird. Wenn wir dann 4.0 für `y` angeben, das wir so
 definiert haben, dass es den gleichen Typ wie `x` hat, erhalten wir einen
 Typfehler wie diesen:
@@ -472,9 +472,9 @@ generische Datentypen verwendet. *Codeduplizierung* (monomorphization) ist der
 Vorgang der Umwandlung von generischem Code in spezifischen Code durch
 Ausfüllen der konkreten Typen, die bei der Kompilierung verwendet werden.
 
-Bei diesem Prozess führt der Kompilierer das Gegenteil der Schritte aus, die
+Bei diesem Prozess führt der Compiler das Gegenteil der Schritte aus, die
 wir beim Erstellen der generischen Funktion in Codeblock 10-5 angewendet haben: 
-Der Kompilierer schaut sich alle Stellen an, an denen generischer Code
+Der Compiler schaut sich alle Stellen an, an denen generischer Code
 aufgerufen wird, und generiert Code für die konkreten Typen, mit denen der
 generische Code aufgerufen wird.
 
@@ -487,14 +487,14 @@ let float = Some(5.0);
 ```
 
 Wenn Rust diesen Code kompiliert, führt es eine Codeduplizierung durch. Während
-dieses Vorgangs liest der Kompilierer die Werte ein, die in
+dieses Vorgangs liest der Compiler die Werte ein, die in
 `Option<T>`-Instanzen verwendet wurden, und identifiziert zwei Arten von
 `Option<T>`: Eine verwendet den Typ `i32` und die andere `f64`. Daraufhin
 erweitert es die generische Definition von `Option<T>` zu `Option_i32` und
 `Option_f64` und ersetzt damit die generische Definition durch die spezifische.
 
 Die duplizierte Codeversion sieht wie folgt aus. Die generische `Option<T>`
-wird durch die vom Kompilierer erstellten spezifischen Definitionen ersetzt:
+wird durch die vom Compiler erstellten spezifischen Definitionen ersetzt:
 
 <span class="filename">Dateiname: src/main.rs</span>
 

--- a/src/ch10-02-traits.md
+++ b/src/ch10-02-traits.md
@@ -1,6 +1,6 @@
 ## Merkmale (traits): Gemeinsames Verhalten definieren
 
-Ein *Merkmal* (trait) teilt dem Rust-Kompilierer mit, welche Funktionalität ein
+Ein *Merkmal* (trait) teilt dem Rust-Compiler mit, welche Funktionalität ein
 bestimmter Typ hat und mit anderen Typen teilen kann. Wir können Merkmale
 verwenden, um gemeinsames Verhalten auf abstrakte Weise zu definieren. Wir
 können Merkmalsabgrenzungen (trait bounds) verwenden, um anzugeben, dass ein
@@ -53,7 +53,7 @@ der Typen beschreiben, die dieses Merkmal implementieren, was in diesem Fall
 Nach der Methodensignatur verwenden wir statt einer Implementierung in
 geschweiften Klammern ein Semikolon. Jeder Typ, der dieses Merkmal
 implementiert, muss sein eigenes benutzerdefiniertes Verhalten für den
-Methodenrumpf bereitstellen. Der Kompilierer wird sicherstellen, dass jeder
+Methodenrumpf bereitstellen. Der Compiler wird sicherstellen, dass jeder
 Typ, der das Merkmal `Summary` hat, die Methode `summarize` mit genau dieser
 Signatur hat.
 
@@ -478,7 +478,7 @@ aufruft, weiß das nicht.
 Die Fähigkeit, einen Typ zurückzugeben, der nur durch das Merkmal spezifiziert
 ist, das er implementiert, ist besonders nützlich im Zusammenhang mit
 Funktionsabschlüssen und Iteratoren, die wir in Kapitel 13 behandeln.
-Funktionsabschlüsse und Iteratoren erzeugen Typen, die nur der Kompilierer
+Funktionsabschlüsse und Iteratoren erzeugen Typen, die nur der Compiler
 kennt oder deren Spezifikation sehr lang ist. Mit der Syntax `impl Trait`
 kannst du prägnant angeben, dass eine Funktion einen Typ zurückgibt, der das
 Merkmal `Iterator` implementiert, ohne dass du einen sehr langen Typ schreiben
@@ -548,7 +548,7 @@ fn returns_summarizable(switch: bool) -> impl Summary {
 
 Die Rückgabe entweder eines `NewsArticle` oder eines `Tweet` ist aufgrund von
 Einschränkungen hinsichtlich der Implementierung der Syntax `impl Trait` im
-Kompilierer nicht erlaubt. Wie man eine Funktion mit diesem Verhalten schreibt,
+Compiler nicht erlaubt. Wie man eine Funktion mit diesem Verhalten schreibt,
 wird im Abschnitt [„Merkmalsobjekte (trait objects) die Werte unterschiedlicher
 Typen erlauben“][using-trait-objects-that-allow-for-values-of-different-types]
 in Kapitel 17 behandelt.
@@ -787,8 +787,8 @@ Abschnitt „Implementierer“ (implementors).
 
 Mithilfe von Merkmalen und Merkmalsabgrenzungen können wir Code schreiben, der
 generische Typparameter verwendet, um Duplikationen zu reduzieren, aber auch
-dem Kompilierer gegenüber angeben, dass der generische Typ ein bestimmtes
-Verhalten haben soll. Der Kompilierer kann dann die Merkmalsabgrenzungen
+dem Compiler gegenüber angeben, dass der generische Typ ein bestimmtes
+Verhalten haben soll. Der Compiler kann dann die Merkmalsabgrenzungen
 verwenden, um zu überprüfen, ob alle konkreten Typen, die von unserem Code
 verwendet werden, das richtige Verhalten aufweisen. In dynamisch typisierten
 Sprachen würden wir einen Laufzeitfehler erhalten, wenn wir eine Methode bei

--- a/src/ch10-03-lifetime-syntax.md
+++ b/src/ch10-03-lifetime-syntax.md
@@ -94,7 +94,7 @@ checker).
 
 ### Der Ausleihenprüfer
 
-Der Rust-Kompilierer verfügt über einen *Ausleihenprüfer* (borrow checker), der
+Der Rust-Compiler verfügt über einen *Ausleihenprüfer* (borrow checker), der
 Gültigkeitsbereiche vergleicht, um festzustellen, ob alle Ausleihen gültig
 sind. Codeblock 10-18 zeigt den gleichen Code wie Codeblock 10-17, jedoch mit
 Annotationen, die die Lebensdauer der Variablen angeben.
@@ -463,7 +463,7 @@ Als Menschen können wir uns diesen Code ansehen und erkennen, dass `string1`
 länger als `string2` ist und deshalb wird `result` eine Referenz auf `string1`
 enthalten. Da `string1` den Gültigkeitsbereich noch nicht verlassen hat, wird
 eine Referenz auf `string1` in der `println!`-Anweisung noch gültig sein. Der
-Kompilierer kann jedoch nicht sehen, dass die Referenz in diesem Fall gültig
+Compiler kann jedoch nicht sehen, dass die Referenz in diesem Fall gültig
 ist. Wir haben Rust gesagt, dass die Lebensdauer der Referenz, die von der
 Funktion `longest` zurückgegeben wird, die gleiche ist wie die kürzere der
 Lebensdauern der entgegengenommenen Referenzen. Daher lehnt der Ausleihenprüfer
@@ -670,25 +670,25 @@ Nachdem jede Menge Rust-Code geschrieben wurde, stellte das Rust-Team fest,
 dass die Rust-Programmierer in bestimmten Situationen immer wieder die gleichen
 Lebensdauer-Annotationen angaben. Diese Situationen waren vorhersehbar und
 folgten einigen wenigen deterministischen Mustern. Die Entwickler
-programmierten diese Muster in den Code des Kompilierers, sodass der
+programmierten diese Muster in den Code des Compilers, sodass der
 Ausleihenprüfer in diesen Situationen auf die Lebensdauer schließen konnte und
 keine expliziten Annotationen benötigte.
 
 Dieses Stück Rust-Geschichte ist relevant, weil es möglich ist, dass weitere
-deterministische Muster auftauchen und dem Kompilierer hinzugefügt werden. In
+deterministische Muster auftauchen und dem Compiler hinzugefügt werden. In
 Zukunft könnten noch weniger Lebensdauer-Annotationen erforderlich sein.
 
 Die Muster, die in Rusts Referenzanalyse programmiert sind, werden die
 *Lebensdauer-Elisionsregeln* (lifetime elision rules) genannt. Dies sind keine
 Regeln, die Programmierer befolgen müssen; es handelt sich um eine Reihe
-besonderer Fälle, die der Kompilierer berücksichtigt, und wenn dein Code zu
+besonderer Fälle, die der Compiler berücksichtigt, und wenn dein Code zu
 einem dieser Fälle passt, brauchst du die Lebensdauer nicht explizit anzugeben.
 
 Die Elisionsregeln bieten keine vollständige Schlussfolgerung. Wenn Rust die
 Regeln deterministisch anwendet, aber immer noch Unklarheit darüber besteht,
-welche Lebensdauer die Referenzen haben, wird der Kompilierer nicht erraten,
+welche Lebensdauer die Referenzen haben, wird der Compiler nicht erraten,
 wie lang die Lebensdauer der verbleibenden Referenzen sein sollte. In diesem
-Fall gibt dir der Kompilierer statt einer Vermutung einen Fehler an, den du
+Fall gibt dir der Compiler statt einer Vermutung einen Fehler an, den du
 beheben kannst, indem du die Lebensdauer-Annotationen angibst, die festlegen,
 wie sich die Referenzen zueinander verhalten.
 
@@ -696,12 +696,12 @@ Die Lebensdauern der Funktions- oder Methodenparameter werden als
 *Eingangslebensdauern* (input lifetimes) bezeichnet, und die Lebensdauern der
 Rückgabewerte als *Ausgangslebensdauern* (output lifetimes) bezeichnet.
 
-Der Kompilierer verwendet drei Regeln, um herauszufinden, welche Lebensdauer
+Der Compiler verwendet drei Regeln, um herauszufinden, welche Lebensdauer
 Referenzen haben, wenn keine expliziten Annotationen vorhanden sind. Die erste
 Regel gilt für Eingangslebensdauern und die zweite und dritte Regel gelten für
-Ausgangslebensdauern. Wenn der Kompilierer das Ende der drei Regeln erreicht
+Ausgangslebensdauern. Wenn der Compiler das Ende der drei Regeln erreicht
 und es immer noch Referenzen gibt, für die er keine Lebensdauern ermitteln
-kann, bricht der Kompilierer mit einem Fehler ab. Diese Regeln gelten sowohl
+kann, bricht der Compiler mit einem Fehler ab. Diese Regeln gelten sowohl
 für `fn`-Definitionen als auch für `impl`-Blöcke.
 
 Die erste Regel ist, dass jeder Parameter, der eine Referenz ist, seinen
@@ -720,7 +720,7 @@ die Lebensdauer von `self` allen Ausgangslebensdauer-Parametern zugewiesen.
 Diese dritte Regel macht Methoden viel angenehmer zu lesen und zu schreiben,
 weil weniger Symbole erforderlich sind.
 
-Tun wir so, als wären wir der Kompilierer. Wir werden diese Regeln anwenden, um
+Tun wir so, als wären wir der Compiler. Wir werden diese Regeln anwenden, um
 herauszufinden, wie lang die Lebensdauer der Referenzen in der Signatur der
 Funktion `first_word` in Codeblock 10-26 ist. Die Signatur beginnt ohne
 Lebensdauern:
@@ -729,7 +729,7 @@ Lebensdauern:
 fn first_word(s: &str) -> &str {
 ```
 
-Dann wendet der Kompilierer die erste Regel an, die festlegt, dass jeder
+Dann wendet der Compiler die erste Regel an, die festlegt, dass jeder
 Parameter seine eigene Lebensdauer erhält. Wir nennen sie wie üblich `'a`, also
 sieht die Signatur jetzt so aus:
 
@@ -747,7 +747,7 @@ fn first_word<'a>(s: &'a str) -> &'a str {
 ```
 
 Jetzt haben alle Referenzen in dieser Funktionssignatur eine Lebensdauer und
-der Kompilierer kann seine Analyse fortsetzen, ohne dass der Programmierer die
+der Compiler kann seine Analyse fortsetzen, ohne dass der Programmierer die
 Lebensdauer in dieser Funktionssignatur annotieren muss.
 
 Schauen wir uns ein anderes Beispiel an, diesmal mit der Funktion `longest`,
@@ -772,7 +772,7 @@ eine Funktion ist, keine Methode, sodass keiner der Parameter `self` ist.
 Nachdem wir alle drei Regeln durchgearbeitet haben, haben wir immer noch nicht
 herausgefunden, wie lang die Lebensdauer des Rückgabetyps ist. Aus diesem Grund
 haben wir beim Versuch, den Code in Codeblock 10-21 zu kompilieren, einen
-Fehler erhalten: Der Kompilierer arbeitete die Lebensdauer-Elisionsregeln
+Fehler erhalten: Der Compiler arbeitete die Lebensdauer-Elisionsregeln
 durch, konnte aber immer noch nicht alle Lebensdauern der Referenzen in der
 Signatur ermitteln.
 

--- a/src/ch13-01-closures.md
+++ b/src/ch13-01-closures.md
@@ -367,12 +367,12 @@ zugänglich zu machen.
 
 Funktionsabschlüsse sind für gewöhnlich kurz und eher in einem begrenzten Kontext
 relevant, als in einem beliebigen Szenario. Innerhalb dieses beschränkten
-Einsatzbereichs ist der Kompilierer verlässlich in der Lage, Typen, Parameter und
+Einsatzbereichs ist der Compiler verlässlich in der Lage, Typen, Parameter und
 Rückgabewerte zu inferieren, ähnlich wie er meistens bei Variablen die Typen
 herleiten kann.
 
 Den Programmierer die Typen in diesen kurzen, anonymen Funktionen anmerken zu
-lassen wäre nur störend und überflüssig, da der Kompilierer bereits über die
+lassen wäre nur störend und überflüssig, da der Compiler bereits über die
 dafür notwendigen Informationen verfügt.
 
 Wir können wie bei Variablen Typanmerkungen angeben, wenn wir die Klarheit
@@ -467,7 +467,7 @@ let n = example_closure(5);
 <span class="caption">Codeblock 13-8: Versuchter Aufruf eines Funktionsabschluss
 den zwei unterschiedliche Typen zugewiesen wurden</span>
 
-Der Kompilierer gibt diesen Fehler aus:
+Der Compiler gibt diesen Fehler aus:
 
 ```console
 $ cargo run
@@ -897,7 +897,7 @@ error[E0434]: can't capture dynamic environment in a fn item
   |
   = help: use the `|| { ... }` closure form instead
 ```
-Der Kompilierer erinnert uns sogar daran, dass dies nur mit Funktionsabschlüssen
+Der Compiler erinnert uns sogar daran, dass dies nur mit Funktionsabschlüssen
 funktioniert!
 
 Wenn ein Funktionsabschluss einen Wert aus seiner Umgebung erfasst, benutzt er
@@ -1002,7 +1002,7 @@ im `println!`-Statement benutzen. Durch Entfernen von `println!` wird dieser
 Fehler behoben.
 
 Wenn du eine `Fn`-Merkmalsabgrenzung spezifizierst, reicht es zumeist wenn du
-mit `Fn` beginnst. Der Kompilierer wird dir mitteilen, wenn es notwendig ist
+mit `Fn` beginnst. Der Compiler wird dir mitteilen, wenn es notwendig ist
 `FnMut` oder `FnOnce` anzugeben, basierend auf dem was im
 Funktionsabschluss-Rumpf passiert. 
 

--- a/src/title-page.md
+++ b/src/title-page.md
@@ -21,7 +21,7 @@ einfacher zu lernen machen. Diese Fassung des Buchs enthält eine Reihe von
 - Kapitel 11 hat einen neuen Abschnitt „Verwenden von `Result<T, E>` in Tests“,
   der zeigt, wie man Tests schreibt, die den Operator `?` verwenden.
 - Der Abschnitt „Fortgeschrittene Lebensdauern“ in Kapitel 19 wurde entfernt,
-  weil die verwendeten Konstrukte durch Kompilierer-Verbesserungen noch
+  weil die verwendeten Konstrukte durch Compiler-Verbesserungen noch
   seltener geworden sind.
 - Der frühere Anhang D „Makros“ wurde um prozedurale Makros erweitert und in
   den Abschnitt „Makros“ in Kapitel 19 verschoben.
@@ -36,7 +36,7 @@ einfacher zu lernen machen. Diese Fassung des Buchs enthält eine Reihe von
 
 Beachte, dass jeder kompilierbare Programmcode aus früheren Fassungen des Buchs
 weiterhin kompiliert, wenn `edition="2018"` nicht in *Cargo.toml* des Projekts
-nicht angegeben wird, selbst wenn du die verwendete Rust-Kompilierer-Version
+nicht angegeben wird, selbst wenn du die verwendete Rust-Compiler-Version
 aktualisierst. Das ist die Rückwärtskompatibilitätsgarantie von Rust!
 
 Die HTML-Version ist online verfügbar unter


### PR DESCRIPTION
Korrigiert Fehler #116: "Kompilierer" nicht im Duden

Fixes #116.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rust-lang-de/rustbook-de/117)
<!-- Reviewable:end -->
