### PR TITLE
fehlendes .take(2) in Codeblock 20-25 hinzugefügt

### DIFF
--- a/src/ch20-03-graceful-shutdown-and-cleanup.md
+++ b/src/ch20-03-graceful-shutdown-and-cleanup.md
@@ -836,7 +836,7 @@ fn main() {
     let listener = TcpListener::bind("127.0.0.1:7878").unwrap();
     let pool = ThreadPool::new(4);
 
-    for stream in listener.incoming() {
+    for stream in listener.incoming().take(2) {
         let stream = stream.unwrap();
 
         pool.execute(|| {


### PR DESCRIPTION
Ist wohl untergegangen. Weiter unten in der vollständigen Codereferenz zum Ende des Kapitels ist es aber mit drin :-)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rust-lang-de/rustbook-de/195)
<!-- Reviewable:end -->
