### PR TITLE
GitHub-Sprachstatistik korrigieren

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.md linguist-language=Markdown

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.md linguist-language=Markdown linguist-detectable -linguist-documentation
+*.md linguist-language=Markdown linguist-detectable

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.md linguist-language=Markdown linguist-vendored=false
+*.md linguist-language=Markdown liguist-detectable=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.md linguist-language=Markdown liguist-detectable
+*.md linguist-language=Markdown liguist-detectable -linguist-documentation

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.md linguist-language=Markdown liguist-detectable -linguist-documentation
+*.md linguist-language=Markdown linguist-detectable -linguist-documentation

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.md linguist-language=Markdown
+*.md linguist-language=Markdown linguist-vendored=false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.md linguist-language=Markdown liguist-detectable=true
+*.md linguist-language=Markdown liguist-detectable


### PR DESCRIPTION
Aktuelle Sprachstatistik von GitHub:
- JavaScript - 62.2%
- CSS - 37.8%

Problem: Die Markdown-Dateien werden nicht mit einbezogen, stellen hier aber den wesentlichen Inhalt dar.

Lösung: Datei `.gitattributes` erstellen mit entsprechender Konfiguration

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rust-lang-de/rustbook-de/200)
<!-- Reviewable:end -->
