### PR TITLE
Alten Absatz entfernen

### DIFF
--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -312,12 +312,6 @@ veränderbare Referenz `r3` erstellt wird. Diese Gültigkeitsbereiche
 erkennen, dass die Referenz bereits vor dem Ende des Gültigkeitsbereichs nicht
 mehr verwendet wird.
 
-Die Fähigkeit des
-Compilers zu erkennen, dass eine Referenz an einem Punkt vor dem Ende des
-Gültigkeitsbereichs nicht mehr verwendet wird, wird als *nicht-lexikalische
-Lebensdauer* (Non-Lexical Lifetimes, kurz NLL) bezeichnet, und du kannst mehr
-darüber in [The Edition Guide][nll] lesen.
-
 Auch wenn Fehler durch Ausleihen manchmal frustrierend sein können, denke
 daran, dass es der Rust-Compiler ist, der frühzeitig (zur Kompilierzeit und
 nicht zur Laufzeit) auf einen möglichen Fehler hinweist und dir genau zeigt, wo


### PR DESCRIPTION
Alten Absatz mit kaputtem Link entfernen, ist im englischen Original nicht mehr enthalten.
Fixes #309