### PR TITLE
Ändere „Beschatten“ zu „Verschatten“

### DIFF
--- a/src/ch02-00-guessing-game-tutorial.md
+++ b/src/ch02-00-guessing-game-tutorial.md
@@ -903,8 +903,8 @@ let guess: u32 = guess.trim().parse().expect("Bitte gib eine Zahl ein!");
 
 Wir erstellen eine Variable mit dem Namen `guess`. Aber warte, hat das Programm
 nicht bereits eine Variable namens `guess`? Ja, aber Rust erlaubt uns, den
-vorherigen Wert von `guess` mit einem neuen Wert zu beschatten (shadow). Durch
-das *Beschatten* können wir den Variablennamen `guess` wiederverwenden, anstatt
+vorherigen Wert von `guess` mit einem neuen Wert zu verschatten (shadow). Durch
+das *Verschatten* können wir den Variablennamen `guess` wiederverwenden, anstatt
 uns zu zwingen, zwei eindeutige Variablen zu erstellen, z.B. `guess_str` und
 `guess`. Wir werden dies in [Kapitel 3][shadowing] ausführlicher behandeln,
 aber für den Moment solltst du wissen, dass diese Funktionalität oft verwendet
@@ -1309,6 +1309,6 @@ besprochen und in Kapitel 6 wird die Funktionsweise von Aufzählungen erläutert
 [recover]: ch09-02-recoverable-errors-with-result.html
 [result]: https://doc.rust-lang.org/std/result/enum.Result.html
 [semver]: https://semver.org/lang/de/
-[shadowing]: ch03-01-variables-and-mutability.html#beschatten-shadowing
+[shadowing]: ch03-01-variables-and-mutability.html#verschatten-shadowing
 [string]: https://doc.rust-lang.org/std/string/struct.String.html
 [variables-and-mutability]: ch03-01-variables-and-mutability.html

--- a/src/ch03-01-variables-and-mutability.md
+++ b/src/ch03-01-variables-and-mutability.md
@@ -164,17 +164,17 @@ Code-Betreuern zu vermitteln. Es ist auch hilfreich, nur eine Stelle in deinem
 Code zu haben, die du ändern musst, wenn der hartkodierte Wert in Zukunft
 aktualisiert werden müsste.
 
-### Beschatten (shadowing)
+### Verschatten (shadowing)
 
 Wie du in der Anleitung zum Ratespiel in [Kapitel
 2][comparing-the-guess-to-the-secret-number] gesehen hast, kannst du eine neue
 Variable mit dem gleichen Namen wie eine vorherige Variable deklarieren. Die
-Rust-Entwickler sagen, dass die erste Variable von der zweiten *beschattet*
+Rust-Entwickler sagen, dass die erste Variable von der zweiten *verschattet*
 (shadowed) wird, was bedeutet, dass die zweite Variable das ist, was der
 Compiler sieht, wenn du den Namen der Variable verwendest. Die zweite Variable
-beschattet die erste und nimmt alle Verwendungen des Variablennamens auf sich,
-bis sie entweder selbst beschattet wird oder der Gültigkeitsbereich endet. Wir
-können eine Variable beschatten, indem wir denselben Variablenamen verwenden
+verschattet die erste und nimmt alle Verwendungen des Variablennamens auf sich,
+bis sie entweder selbst verschattet wird oder der Gültigkeitsbereich endet. Wir
+können eine Variable verschatten, indem wir denselben Variablenamen verwenden
 und das Schlüsselwort `let` wie folgt wiederholen:
 
 <span class="filename">Dateiname: src/main.rs</span>
@@ -213,14 +213,14 @@ Der Wert von x im inneren Gültigkeitsbereich ist: 12
 Der Wert von x ist: 6
 ```
 
-Beschatten unterscheidet sich vom Markieren einer Variable mit `mut`, weil wir
+Verschatten unterscheidet sich vom Markieren einer Variable mit `mut`, weil wir
 einen Kompilierfehler erhalten, wenn wir versehentlich versuchen, diese
 Variable neu zuzuweisen, ohne das Schlüsselwort `let` zu verwenden. Durch das
 Verwenden von `let` können wir einige wenige Transformationen an einem Wert
 durchführen, aber die Variable ist unveränderbar, nachdem diese
 Transformationen abgeschlossen sind.
 
-Der andere Unterschied zwischen `mut` und Beschatten besteht darin, dass wir,
+Der andere Unterschied zwischen `mut` und Verschatten besteht darin, dass wir,
 weil wir effektiv eine neue Variable erstellen, wenn wir das Schlüsselwort
 `let` erneut verwenden, den Typ des Wertes ändern können, aber denselben Namen
 wiederverwenden. Nehmen wir zum Beispiel an, unser Programm bittet einen
@@ -234,7 +234,7 @@ let spaces = spaces.len();
 ```
 
 Die erste Variable `spaces` ist ein String-Typ und die zweite Variable `spaces`
-ist ein Zahlentyp Integer. Das Beschatten erspart es uns also, uns verschiedene
+ist ein Zahlentyp Integer. Das Verschatten erspart es uns also, uns verschiedene
 Namen auszudenken, z.B. `spaces_str` und `spaces_num`; stattdessen können wir
 den einfacheren Namen `spaces` wiederverwenden. Wenn wir jedoch versuchen,
 dafür `mut` zu verwenden, wie hier gezeigt, erhalten wir einen Kompilierfehler:

--- a/src/ch18-03-pattern-syntax.md
+++ b/src/ch18-03-pattern-syntax.md
@@ -31,7 +31,7 @@ jedoch eine Komplikation, wenn du benannte Variablen in `match`-Ausdrücken
 verwendest. Da `match` einen neuen Gültigkeitsbereich beginnt, werden
 Variablen, die als Teil eines Musters innerhalb des `match`-Ausdrucks
 deklariert sind, diejenigen mit dem gleichen Namen außerhalb des
-`match`-Konstrukts beschatten (shadow), wie es bei allen Variablen der Fall
+`match`-Konstrukts verschatten (shadow), wie es bei allen Variablen der Fall
 ist. In Codeblock 18-11 deklarieren wir eine Variable mit dem Namen `x` mit dem
 Wert `Some(5)` und eine Variable `y` mit dem Wert `10`. Dann erzeugen wir einen
 `match`-Ausdruck für den Wert `x`. Sieh dir die Muster in den `match`-Zweigen
@@ -756,7 +756,7 @@ Abgleichsbedingung verwenden können, um dieses Problem zu beheben.
 Testen der Gleichheit mit einer äußeren Variablen</span>
 
 Dieser Code gibt nun `Standardfall, x = Some(5)` aus. Das Muster im zweiten
-`match`-Zweig führt keine neue Variable `y` ein, die das äußere `y` beschatten
+`match`-Zweig führt keine neue Variable `y` ein, die das äußere `y` verschatten
 würde, was bedeutet, dass wir das äußere `y` in der Abgleichsbedingung
 verwenden können. Anstatt das Muster mit `Some(y)` zu spezifizieren, was das
 äußere `y` beschattet hätte, spezifizieren wir `Some(n)`. Dies erzeugt eine


### PR DESCRIPTION
„Verschatten“ ist leicht negativ konnotiert und hat Ähnlichkeit zu „verbergen/verdecken“, weswegen es passender ist. „Beschatten“ ist hingegen eher positiv konnotiert und wirkt in diesem Zusammenhang komisch, weil das Verdecken einer Variable nicht als positiv für sie anzusehen ist.

Ich war übrigens absolut begeistert, als ich gesehen habe, dass ihr Anglizismen nach Möglichkeit vermeidet und eine sehr schöne, deutsche Dokumentation geschrieben habt! Besten Dank!