### PR TITLE
Fix verwirrende Formulierung in ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md

### DIFF
--- a/src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md
+++ b/src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md
@@ -261,7 +261,7 @@ an.
 
 Auf dem absoluten Pfad beginnen wir mit `crate`, der Wurzel des Modulbaums
 unserer Kiste. Dann wird das Modul `front_of_house` in der Kistenwurzel
-definiert. Da das Modul `front_of_house` ist nicht öffentlich, weil die
+definiert. Während das Modul `front_of_house` nicht öffentlich ist, weil die
 `eat_at_restaurant`-Funktion im gleichen Modul wie `front_of_house` definiert
 ist (d.h. `eat_at_restaurant` und `front_of_house` sind Geschwister), können
 wir auf `front_of_house` von `eat_at_restaurant` aus zugreifen. Als nächstes


### PR DESCRIPTION
Fix #329 

"Während" entspricht dem englischen Originaltext.
"Obwohl" wäre aber eventuell noch klarer.