### PR TITLE
Update ch05-03-method-syntax.md

### DIFF
--- a/src/ch05-03-method-syntax.md
+++ b/src/ch05-03-method-syntax.md
@@ -316,7 +316,7 @@ Wert zweimal angeben zu müssen:
 #
 impl Rectangle {
     fn square(size: u32) -> Self {
-        Rectangle {
+        Self {
             width: size,
             height: size,
         }


### PR DESCRIPTION
Use Self in Rectangle::square, like the text says.

The english version does this too.