### PR TITLE
Update ch13-01-closures.html

### DIFF
--- a/ch13-01-closures.html
+++ b/ch13-01-closures.html
@@ -510,7 +510,7 @@ fn main() {
 Funktionsabschluss des Strangs zu erzwingen, die Eigentümerschaft an <code>list</code> zu
 übernehmen</span></p>
 <p>Wir starten einen neuen Strang und geben ihm einen Funktionsabschluss als
-Argument mit. Der Rumps des Funktionsabschlusses gibt die Liste aus. In
+Argument mit. Der Rumpf des Funktionsabschlusses gibt die Liste aus. In
 Codeblock 13-4 hat der Funktionsabschluss nur <code>list</code> mit einer unveränderbaren
 Referenz erfasst, weil das die kleinste Zugriffmenge auf <code>list</code> ist, die
 benötigt wird, um sie auszugeben. In diesem Beispiel müssen wir, obwohl der


### PR DESCRIPTION
Fix typo in documentation: Change "Rumps" to "Rumpf" in description of closures

Corrected a typo in the documentation for better clarity. Changed "Rumps des Funktionsabschlusses" to "Rumpf des Funktionsabschlusses" to accurately describe the function's behavior.