### PR TITLE
fehlendes Referenz-"Zeichen"

### DIFF
--- a/src/ch10-02-traits.md
+++ b/src/ch10-02-traits.md
@@ -320,7 +320,7 @@ verwenden, etwa so:
 #     fn summarize(&self) -> String;
 # }
 #
-pub fn notify(item: impl Summary) {
+pub fn notify(item: &impl Summary) {
     println!("Eilmeldung! {}", item.summarize());
 }
 ```


### PR DESCRIPTION
Hier fehlt ein "&".