### PR TITLE
Fehlendes "vom" in ch12-04-testing-the-librarys-functionality.md

### DIFF
--- a/src/ch12-04-testing-the-librarys-functionality.md
+++ b/src/ch12-04-testing-the-librarys-functionality.md
@@ -4,7 +4,7 @@ Jetzt, da wir die Logik nach *src/lib.rs* extrahiert haben und die
 Argumentkollektion und Fehlerbehandlung in *src/main.rs* belassen haben, ist es
 viel einfacher, Tests für die Kernfunktionalität unseres Codes zu schreiben.
 Wir können Funktionen direkt mit verschiedenen Argumenten aufrufen und
-Rückgabewerte überprüfen, ohne unsere Binärdatei Terminal aus aufrufen zu
+Rückgabewerte überprüfen, ohne unsere Binärdatei vom Terminal aus aufrufen zu
 müssen.
 
 In diesem Abschnitt fügen wir dem `minigrep`-Programm die Suchlogik hinzu,


### PR DESCRIPTION
In Satz _Wir können Funktionen direkt mit verschiedenen Argumenten aufrufen und Rückgabewerte überprüfen, ohne unsere Binärdatei Terminal aus aufrufen zu müssen._ am Anfang von Kap. 12.04. fehlt ein "vom" vor "Terminal".