### PR TITLE
lib.rs nicht ausführbar

### DIFF
--- a/src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md
+++ b/src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md
@@ -34,7 +34,7 @@ sie mit dem Schlüsselwort `pub`. Im Abschnitt [„Pfade mit dem Schlüsselwort
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust,does_not_compile
+```rust,does_not_compile,ignore
 mod front_of_house {
     mod hosting {
         fn add_to_waitlist() {}
@@ -161,7 +161,7 @@ Schlüsselwort `pub`, wie in Listing 7-5 gezeigt.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust,does_not_compile
+```rust,does_not_compile,ignore
 mod front_of_house {
     pub mod hosting {
         fn add_to_waitlist() {}
@@ -334,7 +334,7 @@ sie den Pfad zu `deliver_order` angibt, der mit `super` beginnt:
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 fn deliver_order() {}
 
 mod back_of_house {
@@ -378,7 +378,7 @@ bekommen.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 mod back_of_house {
     pub struct Breakfast {
         pub toast: String,
@@ -433,7 +433,7 @@ Schlüsselwort `enum`, wie in Listing 7-10 gezeigt.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 mod back_of_house {
     pub enum Appetizer {
         Soup,

--- a/src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md
+++ b/src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md
@@ -170,7 +170,7 @@ wie auf sie verwiesen werden kann.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 use std::fmt;
 use std::io;
 
@@ -205,7 +205,7 @@ indem einer der beiden `Result`-Typen mittels `as` umbenannt wird.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 use std::fmt::Result;
 use std::io::Result as IoResult;
 
@@ -339,7 +339,7 @@ einzubinden. Aber wir müssen `use` verwenden, um Elemente von dort in den
 Gültigkeitsbereich unseres Pakets zu bringen. Zum Beispiel würden wir für
 `HashMap` diese Zeile verwenden:
 
-```rust
+```rust,ignore
 use std::collections::HashMap;
 ```
 
@@ -356,7 +356,7 @@ aus `std` in den Gültigkeitsbereich:
 
 <span class="filename">Dateiname: src/main.rs</span>
 
-```rust
+```rust,ignore
 // --abschneiden--
 use std::cmp::Ordering;
 use std::io;
@@ -371,7 +371,7 @@ Listing 7-18 gezeigt.
 
 <span class="filename">Dateiname: src/main.rs</span>
 
-```rust
+```rust,ignore
 // --abschneiden--
 use std::{cmp::Ordering, io};
 // --abschneiden--
@@ -393,7 +393,7 @@ Eine, die `std::io` in den Gültigkeitsbereich bringt, und eine, die
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 use std::io;
 use std::io::Write;
 ```
@@ -408,7 +408,7 @@ verwenden, wie in Listing 7-20 gezeigt wird.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 use std::io::{self, Write};
 ```
 
@@ -423,7 +423,7 @@ Wenn wir _alle_ öffentlichen Elemente, die in einem Pfad definiert sind, in den
 Gültigkeitsbereich bringen wollen, können wir diesen Pfad gefolgt vom
 Stern-Operator `*` angeben:
 
-```rust
+```rust,ignore
 use std::collections::*;
 ```
 

--- a/src/ch10-02-traits.md
+++ b/src/ch10-02-traits.md
@@ -36,7 +36,7 @@ dieses Verhalten zum Ausdruck bringt.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 pub trait Summary {
     fn summarize(&self) -> String;
 }
@@ -75,7 +75,7 @@ Nachricht bereits auf 280 Zeichen begrenzt ist.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 # pub trait Summary {
 #     fn summarize(&self) -> String;
 # }
@@ -181,7 +181,7 @@ in Listing 10-12 getan haben.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 pub trait Summary {
     fn summarize(&self) -> String {
         String::from("(Lies mehr ...)")
@@ -258,7 +258,7 @@ Beispiel könnten wir das Trait `Summary` so definieren, dass wir eine Methode
 Methode `summarize` definieren, die eine Standard-Implementierung hat und die
 Methode `summarize_author` aufruft:
 
-```rust
+```rust,ignore
 pub trait Summary {
     fn summarize_author(&self) -> String;
 
@@ -284,7 +284,7 @@ pub trait Summary {
 Um diese Version von `Summary` zu verwenden, müssen wir `summarize_author` nur
 dann definieren, wenn wir das Trait für einen Typ implementieren:
 
-```rust
+```rust,ignore
 # pub trait Summary {
 #     fn summarize_author(&self) -> String;
 #
@@ -345,7 +345,7 @@ Parameter `item` aufruft, der von einem Typ ist, der das Trait `Summary`
 implementiert. Um dies zu tun, können wir die Syntax `impl Trait` verwenden,
 etwa so:
 
-```rust
+```rust,ignore
 # pub trait Summary {
 #     fn summarize(&self) -> String;
 # }
@@ -397,7 +397,7 @@ Die Syntax `impl Trait` funktioniert für einfache Fälle, ist aber eigentlich
 syntaktischer Zucker für eine längere Form, die _Trait Bound_ genannt wird; sie
 sieht so aus:
 
-```rust
+```rust,ignore
 # pub trait Summary {
 #     fn summarize(&self) -> String;
 # }
@@ -489,7 +489,7 @@ einer Funktion ohne viele Trait Bounds.
 Wir können die Syntax `impl Trait` auch für den Rückgabetyp verwenden, wie hier
 gezeigt:
 
-```rust
+```rust,ignore
 # pub trait Summary {
 #     fn summarize(&self) -> String;
 # }
@@ -549,7 +549,7 @@ zurückgibst. Beispielsweise würde dieser Code, der entweder einen `NewsArticle
 oder einen `SocialPost` mit dem Rückgabetyp `impl Summary` zurückgibt, nicht
 funktionieren:
 
-```rust,does_not_compile
+```rust,does_not_compile,ignore
 # pub trait Summary {
 #     fn summarize(&self) -> String;
 # }
@@ -625,7 +625,7 @@ ermöglichen.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 use std::fmt::Display;
 
 struct Pair<T> {

--- a/src/ch11-01-writing-tests.md
+++ b/src/ch11-01-writing-tests.md
@@ -49,7 +49,7 @@ Listing 11-1 aussehen.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 pub fn add(left: usize, right: usize) -> usize {
     left + right
 }
@@ -317,7 +317,7 @@ und einer Höhe von 1 enthalten kann.
 <span class="filename">Dateiname: src/lib.rs</span>
 
 ```rust,noplayground
-#[derive(Debug)]
+# #[derive(Debug)]
 # struct Rectangle {
 #     width: u32,
 #     height: u32,
@@ -568,7 +568,7 @@ Parameter addiert, und dann testen wir diese Funktion mit dem Makro
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 pub fn add_two(a: u64) -> u64 {
     a + 2
 }
@@ -618,11 +618,11 @@ Lass uns einen Fehler in unseren Code einbringen, um zu sehen, wie `assert_eq!`
 aussieht, wenn es fehlschlägt. Ändern wir die Implementierung der Funktion
 `add_two`, sodass sie stattdessen `3` addiert:
 
-```rust,not_desired_behavior
+```rust,not_desired_behavior,ignore
 pub fn add_two(a: u64) -> u64 {
     a + 3
 }
-
+#
 # #[cfg(test)]
 # mod tests {
 #     use super::*;
@@ -723,7 +723,7 @@ in der Ausgabe auftaucht:
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 pub fn greeting(name: &str) -> String {
     format!("Hallo {name}!")
 }
@@ -751,7 +751,7 @@ Lass uns nun einen Fehler in diesen Code einbringen, indem wir `greeting` so
 ändern, dass `name` nicht enthalten ist, um zu sehen, wie das
 Standard-Testversagen aussieht:
 
-```rust,not_desired_behavior
+```rust,not_desired_behavior,ignore
 pub fn greeting(name: &str) -> String {
     String::from("Hallo!")
 }
@@ -801,7 +801,7 @@ Wert der Funktion `greeting` ausgeben. Fügen wir eine benutzerdefinierte
 Fehlermeldung hinzu, die aus einem Formatierungs-String mit einem Platzhalter
 besteht, der mit dem tatsächlichen Wert aus der Funktion `greeting` gefüllt ist:
 
-```rust
+```rust,ignore
 # pub fn greeting(name: &str) -> String {
 #     String::from("Hallo!")
 # }
@@ -873,7 +873,7 @@ Listing 11-8 zeigt einen Test, der prüft, ob die Fehlerbedingungen von
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 pub struct Guess {
     value: i32,
 }
@@ -929,7 +929,7 @@ Sieht gut aus! Lass uns nun einen Fehler in unseren Code einbringen, indem wir
 die Bedingung entfernen, bei der die Funktion `new` das Programm abbricht, wenn
 der Wert größer als 100 ist:
 
-```rust,not_desired_behavior
+```rust,not_desired_behavior,ignore
 # pub struct Guess {
 #     value: i32,
 # }
@@ -998,7 +998,7 @@ klein oder zu groß ist.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 # pub struct Guess {
 #     value: i32,
 # }
@@ -1046,7 +1046,7 @@ Um zu sehen, was passiert, wenn ein Test mit `should_panic` und einer
 einbringen, indem wir die Zweige `if value < 1` und `else if value > 100`
 vertauschen:
 
-```rust,not_desired_behavior
+```rust,not_desired_behavior,ignore
 # pub struct Guess {
 #     value: i32,
 # }
@@ -1117,7 +1117,7 @@ Tests schreiben, die `Result<T, E>` verwenden! Hier ist der Test aus Listing
 11-1 so umgeschrieben, dass er `Result<T, E>` verwendet und `Err` zurückgibt,
 anstatt das Programm abzubrechen:
 
-```rust
+```rust,ignore
 # pub fn add(left: usize, right: usize) -> usize {
 #     left + right
 # }

--- a/src/ch11-02-running-tests.md
+++ b/src/ch11-02-running-tests.md
@@ -68,7 +68,7 @@ einen Test, der fehlschlägt.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust,panics
+```rust,panics,ignore
 fn prints_and_returns_10(a: i32) -> i32 {
     println!("Ich habe den Wert {a} erhalten.");
     10
@@ -196,7 +196,7 @@ zuerst drei Tests für unsere Funktion `add_two` erstellen, wie in Listing
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 pub fn add_two(a: u64) -> u64 {
     a + 2
 }
@@ -312,7 +312,7 @@ aufzulisten, kannst du die zeitaufwendigen Tests stattdessen mit dem Attribut
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 # pub fn add(left: usize, right: usize) -> usize {
 #     left + right
 # }

--- a/src/ch11-03-test-organization.md
+++ b/src/ch11-03-test-organization.md
@@ -40,7 +40,7 @@ neue Projekt `adder` im ersten Abschnitt dieses Kapitels erstellt haben:
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }
@@ -77,7 +77,7 @@ Funktion `internal_adder`.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 pub fn add_two(a: u64) -> u64 {
     internal_adder(a, 2)
 }
@@ -261,7 +261,7 @@ Testfunktionen in mehreren Testdateien aufrufen wollen:
 
 <span class="filename">Dateiname: tests/common.rs</span>
 
-```rust
+```rust,ignore
 pub fn setup() {
     // Vorbereitungscode speziell für die Tests deiner Bibliothek
 }

--- a/src/ch12-03-improving-error-handling-and-modularity.md
+++ b/src/ch12-03-improving-error-handling-and-modularity.md
@@ -871,7 +871,7 @@ ausfüllen.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust,does_not_compile
+```rust,does_not_compile,ignore
 pub fn search<'a>(query: &str, contents: &'a str) -> Vec<&'a str> {
     unimplemented!();
 }

--- a/src/ch12-04-testing-the-librarys-functionality.md
+++ b/src/ch12-04-testing-the-librarys-functionality.md
@@ -39,7 +39,7 @@ Test.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust,does_not_compile
+```rust,does_not_compile,ignore
 # pub fn search<'a>(query: &str, contents: &'a str) -> Vec<&'a str> {
 #     unimplemented!();
 # }
@@ -85,7 +85,7 @@ produktiv."` enthält.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 pub fn search<'a>(query: &str, contents: &'a str) -> Vec<&'a str> {
     vec![]
 }
@@ -182,7 +182,7 @@ Beachte, dass dies noch nicht kompiliert.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust,does_not_compile
+```rust,does_not_compile,ignore
 pub fn search<'a>(query: &str, contents: &'a str) -> Vec<&'a str> {
     for line in contents.lines() {
         // mache etwas mit line
@@ -225,7 +225,7 @@ kompiliert werden kann.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust,does_not_compile
+```rust,does_not_compile,ignore
 pub fn search<'a>(query: &str, contents: &'a str) -> Vec<&'a str> {
     for line in contents.lines() {
         if line.contains(query) {
@@ -268,7 +268,7 @@ geben wir den Vektor zurück, wie in Listing 12-19 gezeigt.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 pub fn search<'a>(query: &str, contents: &'a str) -> Vec<&'a str> {
     let mut results = Vec::new();
 

--- a/src/ch12-05-working-with-environment-variables.md
+++ b/src/ch12-05-working-with-environment-variables.md
@@ -23,7 +23,7 @@ gezeigt wird.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust,does_not_compile
+```rust,does_not_compile,ignore
 # pub fn search<'a>(query: &str, contents: &'a str) -> Vec<&'a str> {
 #     let mut results = Vec::new();
 #
@@ -104,7 +104,7 @@ wir prüfen, ob die Zeile die Abfrage enthält.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 # pub fn search<'a>(query: &str, contents: &'a str) -> Vec<&'a str> {
 #     let mut results = Vec::new();
 #
@@ -369,7 +369,7 @@ _src/main.rs_ ist. Dann werden wir die Funktion `var` aus dem Modul `env`
 verwenden, um zu prüfen, ob eine Umgebungsvariable namens `IGNORE_CASE` einen
 Wert hat, wie in Listing 12-23 gezeigt.
 
-<span class="filename">Dateiname: src/lib.rs</span>
+<span class="filename">Dateiname: src/main.rs</span>
 
 ```rust,ignore
 # use std::env;

--- a/src/ch13-02-iterators.md
+++ b/src/ch13-02-iterators.md
@@ -65,7 +65,7 @@ Alle Iteratoren implementieren ein Trait namens `Iterator` das in der
 Standardbibliothek definiert ist. Die Definition dieses Traits sieht wie folgt
 aus:
 
-```rust
+```rust,ignore
 pub trait Iterator {
     type Item;
 

--- a/src/ch13-03-improving-our-io-project.md
+++ b/src/ch13-03-improving-our-io-project.md
@@ -445,7 +445,7 @@ Listing 12-19.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 pub fn search<'a>(query: &str, contents: &'a str) -> Vec<&'a str> {
     let mut results = Vec::new();
 
@@ -490,7 +490,7 @@ müssen. Listing 13-22 zeigt diese Änderung.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 pub fn search<'a>(query: &str, contents: &'a str) -> Vec<&'a str> {
     contents
         .lines()

--- a/src/ch14-03-cargo-workspaces.md
+++ b/src/ch14-03-cargo-workspaces.md
@@ -273,7 +273,7 @@ Funktion `add_one::add_one` hinzu:
 
 <span class="filename">Dateiname: add_one/src/lib.rs</span>
 
-```rust
+```rust,ignore
 pub fn add_one(x: i32) -> i32 {
     x + 1
 }

--- a/src/ch15-05-interior-mutability.md
+++ b/src/ch15-05-interior-mutability.md
@@ -168,7 +168,7 @@ namens `Messenger` implementiert. Listing 15-20 zeigt den Bibliothekscode.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 pub trait Messenger {
     fn send(&self, msg: &str);
 }
@@ -237,7 +237,7 @@ erlaubt dies nicht.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust,does_not_compile
+```rust,does_not_compile,ignore
 # pub trait Messenger {
 #     fn send(&self, msg: &str);
 # }
@@ -501,7 +501,7 @@ veranschaulichen, dass `RefCell<T>` uns daran hindert, dies zur Laufzeit zu tun.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust,panics
+```rust,panics,ignore
 # pub trait Messenger {
 #     fn send(&self, msg: &str);
 # }

--- a/src/ch17-01-futures-and-syntax.md
+++ b/src/ch17-01-futures-and-syntax.md
@@ -201,7 +201,7 @@ Funktion, die ein _Future_ des Rückgabetyps zurückgibt. Für den Compiler ist
 eine Funktionsdefinition wie `async fn page_title` in Listing 17-1 fast
 äquivalent zu einer nicht-asynchronen Funktion, die wie folgt definiert ist:
 
-```rust
+```rust,ignore
 use std::future::Future;
 use trpl::Html;
 
@@ -370,7 +370,7 @@ bereit ist, seine Arbeit wieder fortzusetzen. Dies ist eine unsichtbare
 Zustandsmaschine, so als ob du eine Aufzählung auf diese Weise geschrieben
 hättest, um den aktuellen Zustand an jedem `await`-Punkt zu speichern:
 
-```rust
+```rust,ignore
 enum PageTitleFuture<'a> {
     Initial { url: &'a str },
     GetAwaitPoint { url: &'a str },
@@ -476,7 +476,7 @@ unterscheidet `Either` jedoch nicht zwischen Erfolg und Misserfolg.
 Stattdessen werden `Left` und `Right` verwendet, um „das eine oder das andere“
 anzuzeigen.
 
-```rust
+```rust,ignore
 enum Either<A, B> {
     Left(A),
     Right(B),

--- a/src/ch17-05-traits-for-async.md
+++ b/src/ch17-05-traits-for-async.md
@@ -15,7 +15,7 @@ Dokumentation.
 Lass uns zunächst einen genaueren Blick darauf werfen, wie das Trait `Future`
 funktioniert. Rust definiert es wie folgt:
 
-```rust
+```rust,ignore
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -38,7 +38,7 @@ entgegennimmt und `Poll<Self::Output>` zurückgibt. Wir werden gleich ein wenig
 mehr über `Pin` und `Context` sprechen. Für den Moment wollen wir uns auf das
 konzentrieren, was die Methode zurückgibt: Den Typ `Poll`:
 
-```rust
+```rust,ignore
 pub enum Poll<T> {
     Ready(T),
     Pending,
@@ -250,7 +250,7 @@ müssen wir ein wenig tiefer in die Funktionsweise des Traits `Future`
 eintauchen, insbesondere in Bezug auf das Anheften (pinning). Schau dir noch
 einmal die Definition des Traits `Future` an:
 
-```rust
+```rust,ignore
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -552,7 +552,7 @@ Bereitschaft: Seine Methode `poll` liefert ein `Poll<Self::Output>`. Um eine
 Sequenz von Elementen darzustellen, die im Laufe der Zeit bereit sein werden,
 definieren wir ein Trait `Stream`, das diese Funktionalitäten zusammenführt:
 
-```rust
+```rust,ignore
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -592,7 +592,7 @@ wie wir mit Futures direkt über deren Methode `poll` arbeiten _können_. Die
 Verwendung von `await` ist jedoch viel schöner, und das Trait `StreamExt` stellt
 die Methode `next` bereit, sodass wir Folgendes tun können:
 
-```rust
+```rust,ignore
 # use std::pin::Pin;
 # use std::task::{Context, Poll};
 #

--- a/src/ch18-01-what-is-oo.md
+++ b/src/ch18-01-what-is-oo.md
@@ -53,7 +53,7 @@ Definition der Struktur `AveragedCollection`.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 pub struct AveragedCollection {
     list: Vec<i32>,
     average: f64,
@@ -72,7 +72,7 @@ aktualisiert wird. Wir tun dies, indem wir die Methoden `add`, `remove` und
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 # pub struct AveragedCollection {
 #     list: Vec<i32>,
 #     average: f64,

--- a/src/ch18-02-trait-objects.md
+++ b/src/ch18-02-trait-objects.md
@@ -77,7 +77,7 @@ definiert werden kann.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 pub trait Draw {
     fn draw(&self);
 }
@@ -94,7 +94,7 @@ der das Trait `Draw` implementiert.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 # pub trait Draw {
 #     fn draw(&self);
 # }
@@ -114,7 +114,7 @@ gezeigt.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 # pub trait Draw {
 #     fn draw(&self);
 # }
@@ -145,7 +145,7 @@ können.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 # pub trait Draw {
 #     fn draw(&self);
 # }
@@ -193,7 +193,7 @@ gezeigt.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 # pub trait Draw {
 #     fn draw(&self);
 # }

--- a/src/ch18-03-oo-design-patterns.md
+++ b/src/ch18-03-oo-design-patterns.md
@@ -122,7 +122,7 @@ zu halten. Du wirst gleich sehen, warum die `Option<T>` notwendig ist.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 pub struct Post {
     state: Option<Box<dyn State>>,
     content: String,
@@ -176,7 +176,7 @@ hinzufügen.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 # pub struct Post {
 #     state: Option<Box<dyn State>>,
 #     content: String,
@@ -229,7 +229,7 @@ immer leer sein. Listing 18-14 zeigt diese Platzhalter-Implementierung.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 # pub struct Post {
 #     state: Option<Box<dyn State>>,
 #     content: String,
@@ -275,7 +275,7 @@ eines Beitrags zu beantragen, die seinen Zustand von `Draft` in `PendingReview`
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 # pub struct Post {
 #     state: Option<Box<dyn State>>,
 #     content: String,
@@ -384,7 +384,7 @@ sollte, wie in Listing 18-16 gezeigt:
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 # pub struct Post {
 #     state: Option<Box<dyn State>>,
 #     content: String,
@@ -485,7 +485,7 @@ abhängt, also delegieren wir `Post` an eine Methode `content`, die auf seinen
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust,does_not_compile
+```rust,does_not_compile,ignore
 # pub struct Post {
 #     state: Option<Box<dyn State>>,
 #     content: String,
@@ -598,7 +598,7 @@ sehen ist.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 # pub struct Post {
 #     state: Option<Box<dyn State>>,
 #     content: String,
@@ -833,7 +833,7 @@ einmal kompilieren lässt. Listing 18-19 zeigt die Definition einer Struktur
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 pub struct Post {
     content: String,
 }
@@ -895,7 +895,7 @@ gezeigt.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 # pub struct Post {
 #     content: String,
 # }

--- a/src/ch20-01-unsafe-rust.md
+++ b/src/ch20-01-unsafe-rust.md
@@ -202,7 +202,7 @@ Verträge der Funktion übernehmen.
 Hier ist eine unsichere Funktion namens `dangerous`, die in ihrem Rumpf nichts
 tut:
 
-```rust
+```rust,ignore
 unsafe fn dangerous() {}
 
 unsafe {
@@ -510,7 +510,7 @@ Im folgenden Beispiel machen wir die Funktion `call_from_c` von C-Code aus
 zugänglich, nachdem sie in eine gemeinsame Bibliothek kompiliert und von C
 gelinkt wurde:
 
-```rust
+```rust,ignore
 #[unsafe(no_mangle)]
 pub extern "C" fn call_from_c() {
     println!("Rust-Funktion von C aufgerufen!");

--- a/src/ch20-02-advanced-traits.md
+++ b/src/ch20-02-advanced-traits.md
@@ -27,7 +27,7 @@ genannt und steht für den Typ der Werte, über die der Typ, der das Trait
 `Iterator` implementiert, iteriert. Die Definition des Traits `Iterator` ist in
 Listing 20-13 zu sehen.
 
-```rust
+```rust,ignore
 pub trait Iterator {
     type Item;
 
@@ -52,7 +52,7 @@ ist:
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 # struct Counter {
 #     count: u32,
 # }
@@ -82,7 +82,7 @@ Diese Syntax scheint mit der von generischen Datentypen vergleichbar zu sein.
 Warum also nicht einfach das Trait `Iterator` mit generischen Datentypen
 definieren, wie in Listing 20-14 gezeigt?
 
-```rust
+```rust,ignore
 pub trait Iterator<T> {
     fn next(&mut self) -> Option<T>;
 }
@@ -174,7 +174,7 @@ Trait `Add` hat einen assoziierten Typ namens `Output`, der den von der Methode
 Der generische Standardtyp in diesem Code befindet sich innerhalb des Traits
 `Add`. Hier ist seine Definition:
 
-```rust
+```rust,ignore
 trait Add<Rhs=Self> {
     type Output;
 
@@ -207,7 +207,7 @@ Implementierung von `Add` die Umrechnung korrekt durchführen lassen. Wir könne
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 use std::ops::Add;
 
 struct Millimeters(u32);

--- a/src/ch20-04-advanced-functions-and-closures.md
+++ b/src/ch20-04-advanced-functions-and-closures.md
@@ -143,7 +143,7 @@ in Kapitel 10 kennengelernt haben. Du kannst jeden Funktionstyp zurückgeben,
 indem du `Fn`, `FnOnce` und `FnMut` verwendest. Zum Beispiel wird der Code in
 Listing 20-32 problemlos funktionieren.
 
-```rust
+```rust,ignore
 fn returns_closure() -> impl Fn(i32) -> i32 {
     |x| x + 1
 }

--- a/src/ch20-05-macros.md
+++ b/src/ch20-05-macros.md
@@ -85,7 +85,7 @@ Listing 20-35 zeigt eine leicht vereinfachte Definition des Makros `vec!`.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 #[macro_export]
 macro_rules! vec {
     ( $( $x:expr ),* ) => {
@@ -261,7 +261,7 @@ damit assoziierte Funktion.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 pub trait HelloMacro {
     fn hello_macro();
 }

--- a/src/ch21-02-multithreaded.md
+++ b/src/ch21-02-multithreaded.md
@@ -400,7 +400,7 @@ implementieren, die diese Eigenschaften haben wird:
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 pub struct ThreadPool;
 
 impl ThreadPool {
@@ -475,7 +475,7 @@ Parameter vom Typ `F` mit diesen Abgrenzungen annimmt:
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 # pub struct ThreadPool;
 #
 impl ThreadPool {
@@ -538,7 +538,7 @@ Makro `assert!` verwenden, wie in Listing 21-13 gezeigt.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 # pub struct ThreadPool;
 #
 impl ThreadPool {
@@ -619,7 +619,7 @@ diese enthält.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust,not_desired_behavior
+```rust,not_desired_behavior,ignore
 use std::thread;
 
 pub struct ThreadPool {
@@ -725,7 +725,7 @@ Bereit? Hier ist Listing 21-15 mit einer Möglichkeit, die vorhergehenden
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 use std::thread;
 
 pub struct ThreadPool {
@@ -841,7 +841,7 @@ wir in den Kanal senden.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 use std::{sync::mpsc, thread};
 
 pub struct ThreadPool {
@@ -910,7 +910,7 @@ sich noch nicht ganz kompilieren.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust,does_not_compile
+```rust,does_not_compile,ignore
 # use std::{sync::mpsc, thread};
 #
 # pub struct ThreadPool {
@@ -1031,7 +1031,7 @@ wir vornehmen müssen.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 use std::{
     sync::{Arc, Mutex, mpsc},
     thread,
@@ -1118,7 +1118,7 @@ nutzen zu können. Siehe Listing 21-19.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 # use std::{
 #     sync::{Arc, Mutex, mpsc},
 #     thread,
@@ -1209,7 +1209,7 @@ Listing 21-20 gezeigte Änderung in `Worker::new` vornehmen.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 # use std::{
 #     sync::{Arc, Mutex, mpsc},
 #     thread,
@@ -1362,7 +1362,7 @@ nicht geschrieben haben, wie in Listing 21-21 gezeigt.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust,not_desired_behavior
+```rust,not_desired_behavior,ignore
 # use std::{
 #     sync::{Arc, Mutex, mpsc},
 #     thread,

--- a/src/ch21-03-graceful-shutdown-and-cleanup.md
+++ b/src/ch21-03-graceful-shutdown-and-cleanup.md
@@ -26,7 +26,7 @@ funktionieren.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust,does_not_compile
+```rust,does_not_compile,ignore
 # use std::{
 #     sync::{Arc, Mutex, mpsc},
 #     thread,
@@ -277,7 +277,7 @@ um den `sender` mit `Option::take` aus dem `ThreadPool` herausnehmen zu können.
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 # use std::{
 #     sync::{Arc, Mutex, mpsc},
 #     thread,
@@ -637,7 +637,7 @@ fn handle_connection(mut stream: TcpStream) {
 
 <span class="filename">Dateiname: src/lib.rs</span>
 
-```rust
+```rust,ignore
 use std::{
     sync::{Arc, Mutex, mpsc},
     thread,


### PR DESCRIPTION
Codeblöcke mit Bibliothekscode (lib.rs) als nicht ausführbar markieren, weil mdBook diese sonst in ein fn main {} einbettet.

Fixes #412